### PR TITLE
fix(release): add npm plugin for semantic release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -2,6 +2,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
     ["@semantic-release/git", {
       "assets": ["package.json"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"

--- a/.releaserc
+++ b/.releaserc
@@ -11,8 +11,8 @@
       "assets": [
         {
           "path": "./roaster-*.xar", 
-          "name": "roaster-${nextRelease.gitTag}.xar",
-          "label": "Expath package (roaster-${nextRelease.gitTag}.xar)"
+          "name": "roaster-${nextRelease.version}.xar",
+          "label": "Expath package (roaster-${nextRelease.version}.xar)"
         }
       ]
     }]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "roaster",
-  "version": "0.0.0-development",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@existdb/gulp-replace-tmpl": "^1.0.0",
     "@semantic-release/git": "^9.0.0",
     "@semantic-release/github": "^7.2.0",
+    "@semantic-release/npm": "^7.0.9",
     "axios": "^0.21.1",
     "chai": "^4.2.0",
     "chai-openapi-response-validator": "^0.9.4",
@@ -34,6 +35,7 @@
     "semantic-release": "^17.3.2",
     "tmp": "^0.2.1"
   },
+  "private": true,
   "mocha": {
     "timeout": 10000,
     "slow": 1000


### PR DESCRIPTION
the npm plugin takes care of modifying the version in package.json, which will then be committed back to the master branch, once per release.
The publishing to npm is blocked by the "private" property in package.json being set to `true`.