### PR TITLE
fix: route matching regex construction

### DIFF
--- a/content/router.xql
+++ b/content/router.xql
@@ -186,7 +186,7 @@ declare %private function router:create-regex($path as xs:string) as xs:string {
         return replace($component, $router:path-parameter-matcher, $replacement)
     
     return
-        "/" || string-join($replaced, "/")
+        "^/" || string-join($replaced, "/")
 };
 
 (:~

--- a/test/paths.test.js
+++ b/test/paths.test.js
@@ -15,6 +15,17 @@ describe('Path parameters', function () {
         // expect(res).to.satisfyApiSpec;
     });
 });
+
+describe('Prefixed known path', function () {
+    it('should return a not found error', function () {
+        return util.axios.get('not/api/parameters')
+            .then(response => { throw {response} })
+            .catch(error => {
+                expect(error.response.status).to.equal(404)
+            });
+    });
+});
+
 describe("Binary up and download", function () {
     const contents = fs.readFileSync("./roasted.xar")
 


### PR DESCRIPTION
The regular expression that is used to match a request path must begin
with `^`.