### PR TITLE
Add user full name for example to display as greeting

### DIFF
--- a/content/util.xql
+++ b/content/util.xql
@@ -34,6 +34,7 @@ declare function rutil:getDBUser() as map(*) {
     let $name := $user/sm:username/text()
     return map {
         "name": $name,
+        "fullName": (sm:get-account-metadata($name, xs:anyURI('http://axschema.org/namePerson')), $name)[1],
         "groups": array { $user//sm:group/text() },
         "dba" : sm:is-dba($name)
     }


### PR DESCRIPTION
In the eXist user details a full name may have been stored which is useful. For example to be used as a greetting to the user or a button/overlay pointing to his full details.

Use fallback onto eXist-db user name so the UI or other does not have to do that if/then/else