### PR TITLE
feat(util): rutil:getDBUser#0 returns fullname

### DIFF
--- a/content/util.xql
+++ b/content/util.xql
@@ -34,6 +34,7 @@ declare function rutil:getDBUser() as map(*) {
     let $name := $user/sm:username/text()
     return map {
         "name": $name,
+        "fullName": (sm:get-account-metadata($name, xs:anyURI('http://axschema.org/namePerson')), $name)[1],
         "groups": array { $user//sm:group/text() },
         "dba" : sm:is-dba($name)
     }


### PR DESCRIPTION
In eXist's user details a full name may have been stored which is useful.
For example to be used as a greeting to the user or a button/overlay pointing to
their full details.

Falls back to a user's username so that this value can safely used by client.

closes #29 