### PR TITLE
feat(router): reject invalid xml body

### DIFF
--- a/content/router.xql
+++ b/content/router.xql
@@ -265,6 +265,12 @@ declare function router:body ($request as map(*)) {
                         () (: TODO: implement form-data handling? :)
                     case "application/json" return
                         request:get-data() => util:binary-to-string() => parse-json()
+                    case "application/xml" return (
+                        let $data := request:get-data()
+                        let $test := parse-xml($data)
+                        let $xml := $data/node()
+                        return $xml
+                    )
                     default return
                         request:get-data()
             )

--- a/test/app/api.json
+++ b/test/app/api.json
@@ -317,7 +317,7 @@
                 }
             },
             "post": {
-                "summary": "Post body as application/octet-stream",
+                "summary": "Post body with several content-types",
                 "x-constraints": {
                     "user": "admin" 
                 },
@@ -326,6 +326,18 @@
                     "required": true,
                     "content": {
                         "application/octet-stream": {
+                            "schema": {
+                                "type": "string",
+                                "format": "binary"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "type": "string",
+                                "format": "binary"
+                            }
+                        },
+                        "application/json": {
                             "schema": {
                                 "type": "string",
                                 "format": "binary"

--- a/test/paths.test.js
+++ b/test/paths.test.js
@@ -75,6 +75,43 @@ describe("Binary up and download", function () {
     })
 });
 
+describe("body with content-type application/xml", function () {
+    before(async function () {
+        await util.login()
+    })
+    after(function () {
+        return util.logout()
+    })
+
+    describe("with valid content", function () {
+        let uploadResponse
+        before(function () {
+            return util.axios.post('api/paths/valid.xml', Buffer.from('<root/>'), {
+                headers: { 'Content-Type': 'application/xml' }
+            })
+            .then(r => uploadResponse = r)
+            .catch(r => uploadResponse = r)
+        })
+        it("is accepted", function () {
+            expect(uploadResponse.status).to.equal(201)
+        })    
+    })
+
+    describe("with invalid content", function () {
+        let upload
+        before(async function () {
+            return util.axios.post('api/paths/invalid.xml', Buffer.from('<invalid>asdf'), {
+                headers: { 'Content-Type': 'application/xml' }
+            })
+            .then(r => upload = r)
+            .catch(r => upload = r)
+        })
+        it("is rejected", function () {
+            expect(upload.response.status).to.equal(500)
+        })        
+    })
+})
+
 describe('Request body', function() {
     it('uploads string in body', async function() {
         const res = await util.axios.post('api/$op-er+ation*!');


### PR DESCRIPTION
This will align roaster's handling of body content of type "application/xml" with "application/json".
The server will reject any request with invalid XML in the same way it does for invalid JSON already.