### PR TITLE
feat(auth): improve user login and logout

### DIFF
--- a/test/app/api.json
+++ b/test/app/api.json
@@ -19,31 +19,54 @@
             },
             "cookieAuth": {
                 "type": "apiKey",
-                "name": "teipublisher.com.login",
+                "name": "roasted.com.login",
                 "in": "cookie"
             }
         }
     },
     "paths": {
-        "/login": {
+        "/logout": {
             "get": {
-                "operationId": "auth:login",
+                "operationId": "auth:logout",
                 "parameters": [
                     {
                         "name": "logout",
                         "in": "query",
                         "description": "Set to some value to log out the current user",
                         "schema": {
-                            "type": "string",
-                            "nullable": true,
-                            "example": "true"
+                            "type": "string"
                         }
                     }
                 ],
                 "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "success": { "type": "boolean" }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "301": {
+                        "description": "Redirect with the logout parameter set.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
                     "401": { "description": "unauthorized" }
                 }
-            },
+            }
+        },
+        "/login": {
             "post": {
                 "summary": "Login the user",
                 "description": "Login the given user",
@@ -71,22 +94,6 @@
                             "schema": {
                                 "type": "object",
                                 "nullable": true,
-                                "properties": {
-                                    "user": {
-                                        "description": "Name of the user",
-                                        "type": "string"
-                                    },
-                                    "password": {
-                                        "type": "string",
-                                        "format": "password"
-                                    }
-                                }
-                            }
-                        },
-                        "application/json": {
-                            "schema": {
-                            "type": "object",
-                            "nullable": true,
                                 "properties": {
                                     "user": {
                                         "description": "Name of the user",

--- a/test/paths.test.js
+++ b/test/paths.test.js
@@ -112,6 +112,44 @@ describe("body with content-type application/xml", function () {
     })
 })
 
+describe('On Login', function () {
+    let response
+
+    before(async function () {
+        await util.login()
+        response = await util.axios.get('api/parameters', {})
+    })
+
+    it('public route can be called', function () {
+        expect(response.status).to.equal(200);
+    })
+
+    it('user property is set on request map', function () {
+        expect(response.data.user).to.be.a('object')
+        expect(response.data.user.name).to.equal("admin")
+        expect(response.data.user.dba).to.equal(true)
+    })
+
+    describe('On logout', function () {
+        let logoutResponse
+        let guestResponse
+        before(async function () {
+            logoutResponse = await util.axios.get('logout')
+            guestResponse = await util.axios.get('api/parameters', {})
+        })
+        it('request returns true', function () {
+            expect(logoutResponse.status).to.equal(200)
+            expect(logoutResponse.data.success).to.equal(true)
+        })
+        it('public route sets guest as user', function () {
+            expect(guestResponse.status).to.equal(200)
+            expect(guestResponse.data.user.name).to.equal("guest")
+            expect(guestResponse.data.user.dba).to.equal(false)
+        })
+
+    })
+})
+
 describe('Request body', function() {
     it('uploads string in body', async function() {
         const res = await util.axios.post('api/$op-er+ation*!');

--- a/test/util.js
+++ b/test/util.js
@@ -38,11 +38,7 @@ async function login() {
 
 function logout() {
     // console.log('Logging out ...');
-    return axiosInstance.request({
-        url: 'login',
-        method: 'get',
-        params: { logout: "true" }
-    })
+    return axiosInstance.request({ url: 'logout', method: 'get'})
     .catch(_ => Promise.resolve())
 }
 


### PR DESCRIPTION
- add auth:logout to enable cookieAuth logout on any route by
  redirecting with logout parameter if not already set
- fix auth:login to always call login:set-user
- remove unsupported login payload (application/json)
- switch to "roasted.com.login" as test login domain