### PR TITLE
Implement more robust support for mediaType detection

### DIFF
--- a/content/router.xql
+++ b/content/router.xql
@@ -274,8 +274,8 @@ declare function router:body ($request as map(*)) {
                     return $xml
                 )
                 default return
-                    if (contains($type, '+json')) then request:get-data() => util:binary-to-string() => parse-json() else 
-                    if (contains($type, '+xml')) then (request:get-data() => parse-xml())/node() 
+                    if (contains($content-type-header, '+json')) then request:get-data() => util:binary-to-string() => parse-json() else 
+                    if (contains($content-type-header, '+xml')) then (request:get-data() => parse-xml())/node() 
                     else request:get-data()
             
             )


### PR DESCRIPTION
When you submit data with content-type application/json-patch+json, the router does not handle the contents as json but just sends it in as string. There are more mediaTypes like this, e.g. application/fhir+json and application/fhir+xml. This updates tries to be as graceful as possible with mediaTypes that declare +json or +xml.