### PR TITLE
Fix XML upload

### DIFF
--- a/content/router.xql
+++ b/content/router.xql
@@ -326,8 +326,10 @@ declare function router:body ($request as map(*)) {
             :)
             case "xml" return 
                 let $data := request:get-data()
-                let $_test := parse-xml($data)
-                return $data/node()
+                return
+                    typeswitch ($data)
+                    case node() return $data/node()
+                    default return parse-xml($data)
             (: Treat everything else as binary data :)
             default return request:get-data()
         }

--- a/test/mediatype.test.js
+++ b/test/mediatype.test.js
@@ -62,7 +62,7 @@ describe("body with content-type application/xml", function () {
     describe("with valid content", function () {
         let uploadResponse
         const filename = 'valid.xml'
-        const contents = Buffer.from('<root/>')
+        const contents = Buffer.from('<root>\n\t<nested>text</nested>\n</root>')
         before(function () {
             return util.axios.post('api/paths/' + filename, contents, {
                 headers: { 'Content-Type': 'application/xml' }
@@ -78,9 +78,9 @@ describe("body with content-type application/xml", function () {
             expect(uploadResponse.data).to.equal(dbUploadCollection + filename)
         })
         it('can be retrieved', async function () {
-            const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
-            expect(res.status).to.equal(200)
-            expect(res.data).to.eql(contents)
+            const {status, data} = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
+            expect(status).to.equal(200)
+            expect(data).to.eql(contents)
         })
     })
 
@@ -146,7 +146,7 @@ describe("body with content-type application/tei+xml", function () {
     describe("with valid content", function () {
         let uploadResponse
         const filename = 'valid.tei.xml'
-        const contents = Buffer.from('<TEI/>')
+        const contents = Buffer.from('<TEI xmlns="http://www.tei-c.org/ns/1.0">\n\t<teiHeader/>\n\t<text>some text</text>\n</TEI>')
         before(function () {
             return util.axios.post('api/paths/' + filename, contents, {
                 headers: { 'Content-Type': 'application/tei+xml' }


### PR DESCRIPTION
fixes #42
closes #30,#43 

Special thanks to @Bpolitycki for reporting this. This is my proposed solution with working tests added for plain XML and TEI. The main difference to the solution kindly provided by @Bpolitycki is that it checks the type of `$data` returned by `request:get-data()`. If it happens to be of type `node()` we can already safely assume the sent document to be well-formed. Only if that is not the case roaster will then pass the unparsed string to `parse-xml` in order to return the parse error as early as possible. 

This builds on top of #30 which should be approved first.