### PR TITLE
feat: handle form-data

### DIFF
--- a/content/router.xql
+++ b/content/router.xql
@@ -307,13 +307,18 @@ declare function router:body ($request as map(*)) {
     else (
         try {
             switch ($request?format)
-            (: Q: do we need to handle form-data? :)
-            case "form-data" return
-                map:merge(
-                    for $key in request:get-parameter-names()
-                    let $value := request:get-parameter($key, ())
-                    return map { $key : $value }
-                )
+            case "form-data" return (
+                if (request:is-multipart-content())
+                then (map { "__multipart": true() })
+                else 
+                    map:merge(
+                        for $key in request:get-parameter-names()
+                        let $value := request:get-parameter($key, ())
+                        return (
+                            map { $key : $value }
+                        )
+                    )
+            )
             (:
                 Parse body contents to XQuery data structure for media types
                 that were identified as being in JSON format.

--- a/content/router.xql
+++ b/content/router.xql
@@ -284,7 +284,7 @@ declare %private function router:content-type ($request as map(*)) as map(*) {
                     then "json" 
                     else if ($media-type = ("application/xml", "text/xml"))
                     then "xml"
-                    else if ($media-type = "multipart/form-data")
+                    else if ($media-type = ("multipart/form-data", "application/x-www-form-urlencoded"))
                     then "form-data"
                     else if ($format-hint) 
                     then $format-hint 
@@ -308,7 +308,12 @@ declare function router:body ($request as map(*)) {
         try {
             switch ($request?format)
             (: Q: do we need to handle form-data? :)
-            case "form-data" return () 
+            case "form-data" return
+                map:merge(
+                    for $key in request:get-parameter-names()
+                    let $value := request:get-parameter($key, ())
+                    return map { $key : $value }
+                )
             (:
                 Parse body contents to XQuery data structure for media types
                 that were identified as being in JSON format.

--- a/doc/file-upload.md
+++ b/doc/file-upload.md
@@ -1,0 +1,304 @@
+# Uploading files from an HTML form
+
+When uploading a file from an HTML form, the file content is not sent as the request body.
+This is because an HTML form may contain more than one input, and in a POST request all input values will be sent in the request body.
+A form which has an `<input type="file">` must use `enctype="multipart/form-data"`, according to the [specification](https://www.ietf.org/rfc/rfc1867.txt).
+The file content can be sent as raw data, or base64 encoded, according to the [OpenAPI specification](https://swagger.io/docs/specification/describing-request-body/file-upload/):
+"Files use a `type: string` schema with `format: binary` or `format: base64`, depending on how the file contents will be encoded."
+
+How this all works when using Roaster is illustrated in the examples below.
+
+## Text file upload
+
+In this example, the filename is sent as a separate parameter.
+This is not strictly necessary, but it shows how to send a filename which may be different from the original filename as part of the URL path.
+
+First look at the HTML form.
+
+```html
+    <form action="#" method="POST" enctype="multipart/form-data" id="textFileUploadForm"
+      onsubmit="return submitTextFileUpload()"
+    >
+      <fieldset>
+        <legend>Upload a text file.</legend>
+        <p><input type="file" name="file" id="textFileUploadInput"/></p>
+        <p><input type="submit" value="Upload text file"/></p>
+      </fieldset>
+    </form>
+```
+
+The javascript function used for upload:
+
+```javascript
+      /**
+       * Upload a text file.
+       * In this example, the filename is part of the URL, so the form action is modified.
+       * The filename is also sent in the form-data, so this is not really necessary.
+       */
+      function submitTextFileUpload()
+      {
+        const fileName = document.getElementById('textFileUploadInput').files[0].name;
+        document.getElementById('textFileUploadForm').action = `../upload-text/${fileName}`;
+        // Return true to submit immediately.
+        return true;
+      }
+```
+The form is at the URL `static/upload.html`, which is why the relative URL for uploading is `../upload-text/${fileName}`.
+
+The OpenAPI specification for the upload is:
+
+```json
+        "/upload-text/{path}": {
+            "post": {
+                "summary": "Upload a text file.",
+                "description": "In this example, the file path is part of the URL.",
+                "operationId": "file-upload:upload-text",
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "file": { "type": "string", "format": "binary" }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "path",
+                        "in": "path",
+                        "required": true,
+                        "schema":{ "type": "string" }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created uploaded file",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "string" }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Content was invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+```
+
+The request is handled by the XQuery function `file-upload:upload-text`, which uses a function `local:file-path` to determine a location on the file system. Of course you could do something else with the uploaded file.
+
+```xquery
+declare function file-upload:upload-text($request as map(*)) {
+  (: Get the file name from the URL path. :)
+  let $file-path as xs:string? := local:file-path($request?parameters?path)
+  (: Make a text node for serialization. :)
+  let $file-content as node() := text { $request?body?file }
+  let $stored as xs:boolean? :=
+    if (exists($file-path)) then
+      file:serialize-text($file-content, $file-path, ('method=text'))
+    else
+      util:log("error", ``[Cannot store uploaded text file of size `{string-length($file-content)}` without a correct file path]``)
+  return
+    if ($stored) then
+      let $log := util:log("info", ``[Stored uploaded text file of size `{string-length($file-content)}` into `{$file-path}`]``)
+      return
+        roaster:response(201, $stored)
+    else
+      roaster:response(400, $stored)
+};
+```
+
+## Binary file upload
+
+Next is a binary file upload, which can be used for images and other data that does not fit in an `xs:string`.
+The HTML form:
+
+```html
+    <form action="../upload-binary" method="POST" enctype="multipart/form-data" id="binaryFileUploadForm">
+      <fieldset>
+        <legend>Upload a binary file.</legend>
+        <p><input type="file" name="file" id="binaryFileUploadInput"/></p>
+        <p><input type="submit" value="Upload binary file"/></p>
+      </fieldset>
+    </form>
+```
+
+No javascript is needed, so let's move on to the OpenAPI specification.
+
+```json
+        "/upload-binary": {
+            "post": {
+                "summary": "Upload a binary file.",
+                "description": "In this example, the file path is sent as binary form data.",
+                "operationId": "file-upload:upload-binary",
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "file": { "type": "string", "format": "binary" }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [],
+                "responses": {
+                    "201": {
+                        "description": "Created uploaded file",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "string" }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Content was invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+```
+The corresponding XQuery function is `file-upload:upload-binary`.
+
+```xquery
+declare function file-upload:upload-binary($request as map(*)) {
+  let $file-path as xs:string? := local:file-path(request:get-uploaded-file-name('file'))
+  let $file-content as xs:base64Binary := request:get-uploaded-file-data('file')
+  let $file-content-length as xs:double := request:get-uploaded-file-size('file')
+  let $stored as xs:boolean? :=
+    if (exists($file-path)) then
+      file:serialize-binary($file-content, $file-path)
+    else
+      util:log("error", ``[Cannot store uploaded binary file of size `{$file-content-length}` without a correct file path]``)
+  return
+    if ($stored) then
+      let $log := util:log("info", ``[Stored uploaded binary file of size `{$file-content-length}` into `{$file-path}`]``)
+      return
+        roaster:response(201, $stored)
+    else
+      roaster:response(400, $stored)
+};
+```
+
+## Base64 encoded file upload
+
+The previous example shows how to upload binary data unencoded, but since the OpenAPI specification provides a way to upload binary data encoded as base64, why not do that as well?
+
+The HTML form is similar to the one for binary upload, but includes a hidden `data` input for the encoded data.
+
+```html
+    <form action="../upload-base64" method="POST" enctype="multipart/form-data" id="base64FileUploadForm"
+        onsubmit="return submitBase64FileUpload()"
+    >
+      <fieldset>
+        <legend>Upload a binary file encoded as base64.</legend>
+        <p><input type="file" name="file" id="base64FileUploadInput"/>
+          <!-- A hidden field is used for sending the base64 encoded data. -->
+          <input type="hidden" name="data" id="base64FileUploadData"/>
+        </p>
+        <p><input type="submit" value="Upload binary file as base64"/></p>
+      </fieldset>
+    </form>
+```
+
+Base64 encoding is not provided by the HTML form, so we need some javascript.
+
+```javascript
+      function submitBase64FileUpload()
+      {
+        event.preventDefault();
+        const file = document.getElementById('base64FileUploadInput').files[0];
+        const reader = new FileReader();
+        reader.onloadend = function () {
+          // The reader makes a data: URI; remove the prefix and only keep the base64 string.
+          const base64 = reader.result.replace(/^data:.+;base64,/, '');
+          document.getElementById('base64FileUploadData').value = base64;
+          document.getElementById('base64FileUploadForm').submit();
+        };
+        reader.readAsDataURL(file);
+        // Return true to not submit, but wait for the reader to finish.
+        return false;
+      }
+```
+
+This time, the OpenAPI specification uses `"data": { "type": "string", "format": "base64" }`.
+
+```json
+        "/upload-base64": {
+            "post": {
+                "summary": "Upload a binary file, which is encoded as base64.",
+                "operationId": "file-upload:upload-base64",
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "data": { "type": "string", "format": "base64" }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [],
+                "responses": {
+                    "201": {
+                        "description": "Created uploaded file",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "string" }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Content was invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+```
+
+The `file` data is still present in the request, but we will not use it in the XQuery function.
+We could have removed it in the javascript, to save some precious bytes in the request body.
+
+```xquery
+declare function file-upload:upload-base64($request as map(*)) {
+  let $file-path as xs:string? := local:file-path(request:get-uploaded-file-name('file'))
+  let $file-content as xs:base64Binary := xs:base64Binary($request?body?data)
+  let $file-content-length as xs:integer := string-length($request?body?data) * 3 idiv 4 (: approximately :)
+  let $stored as xs:boolean? :=
+    if (exists($file-path)) then
+      file:serialize-binary($file-content, $file-path)
+    else
+      util:log("error", ``[Cannot store uploaded binary file of size `{$file-content-length}` without a correct file path]``)
+  return
+    if ($stored) then
+      let $log := util:log("info", ``[Stored uploaded binary file of size `{$file-content-length}` into `{$file-path}`]``)
+      return
+        roaster:response(201, $stored)
+    else
+      roaster:response(400, $stored)
+};
+```

--- a/doc/file-upload.md
+++ b/doc/file-upload.md
@@ -2,13 +2,15 @@
 
 When uploading a file from an HTML form, the file content is not sent as the request body.
 This is because an HTML form may contain more than one input, and in a POST request all input values will be sent in the request body.
+
 A form which has an `<input type="file">` must use `enctype="multipart/form-data"`, according to the [specification](https://www.ietf.org/rfc/rfc1867.txt).
+
 The file content can be sent as raw data, or base64 encoded, according to the [OpenAPI specification](https://swagger.io/docs/specification/describing-request-body/file-upload/):
 "Files use a `type: string` schema with `format: binary` or `format: base64`, depending on how the file contents will be encoded."
 
 How this all works when using Roaster is illustrated in the examples below.
 
-## Text file upload
+## Uploading a single file
 
 In this example, the filename is sent as a separate parameter.
 This is not strictly necessary, but it shows how to send a filename which may be different from the original filename as part of the URL path.
@@ -16,186 +18,175 @@ This is not strictly necessary, but it shows how to send a filename which may be
 First look at the HTML form.
 
 ```html
-    <form action="#" method="POST" enctype="multipart/form-data" id="textFileUploadForm"
-      onsubmit="return submitTextFileUpload()"
+    <form id="singleFileUploadForm"
+        action="#"
+        method="POST" 
+        enctype="multipart/form-data"
+        onsubmit="uploadSingleFile"
     >
-      <fieldset>
-        <legend>Upload a text file.</legend>
-        <p><input type="file" name="file" id="textFileUploadInput"/></p>
-        <p><input type="submit" value="Upload text file"/></p>
-      </fieldset>
+        <input type="file" name="file" id="singleFileUploadInput"/><br/>
+        <input type="submit" value="Upload text file"/>
     </form>
 ```
 
 The javascript function used for upload:
+The form action is modified to dynamically set the filename as part of the URL.
+The filename is also sent in the form-data, so this is not really necessary (see batch upload example below).
 
 ```javascript
-      /**
-       * Upload a text file.
-       * In this example, the filename is part of the URL, so the form action is modified.
-       * The filename is also sent in the form-data, so this is not really necessary.
-       */
-      function submitTextFileUpload()
-      {
-        const fileName = document.getElementById('textFileUploadInput').files[0].name;
-        document.getElementById('textFileUploadForm').action = `../upload-text/${fileName}`;
+      function uploadSingleFile(event) {
+        const input = document.getElementById('singleFileUploadInput')
+        const fileName = input.files[0].name;
+
+        const form = event.target
+        form.action = `../upload-text/${fileName}`;
         // Return true to submit immediately.
         return true;
       }
 ```
-The form is at the URL `static/upload.html`, which is why the relative URL for uploading is `../upload-text/${fileName}`.
+
+The form is at the URL `static/upload.html`, which is why the relative URL for uploading is `../upload/single/${fileName}`.
 
 The OpenAPI specification for the upload is:
 
 ```json
-        "/upload-text/{path}": {
-            "post": {
-                "summary": "Upload a text file.",
-                "description": "In this example, the file path is part of the URL.",
-                "operationId": "file-upload:upload-text",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "file": { "type": "string", "format": "binary" }
-                                }
+{
+    "/upload/single/{path}": {
+        "post": {
+            "summary": "Upload a single file.",
+            "description": "In this example, the file path is part of the URL.",
+            "operationId": "upload:single",
+            "required": true,
+            "content": {
+                "multipart/form-data": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "file": {
+                                "type": "string",
+                                "format": "binary"                    
                             }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "path",
+                    "in": "path",
+                    "required": true,
+                    "schema":{ "type": "string" }
+                }
+            ],
+            "responses": {
+                "201": {
+                    "description": "Created uploaded file",
+                    "content": {
+                        "application/json": {
+                            "schema": { "type": "string" }
                         }
                     }
                 },
-                "parameters": [
-                    {
-                        "name": "path",
-                        "in": "path",
-                        "required": true,
-                        "schema":{ "type": "string" }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created uploaded file",
-                        "content": {
-                            "application/json": {
-                                "schema": { "type": "string" }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Content was invalid",
-                        "content": {
-                            "application/json": {
-                                "schema": { "type": "string" }
-                            }
+                "400": {
+                    "description": "Content was invalid",
+                    "content": {
+                        "application/json": {
+                            "schema": { "type": "string" }
                         }
                     }
                 }
             }
         }
+    }
+}
 ```
 
-The request is handled by the XQuery function `file-upload:upload-text`, which uses a function `local:file-path` to determine a location on the file system. Of course you could do something else with the uploaded file.
+The request is handled by the XQuery function `upload:single` and 
+writes the file into a collection inside the database.
 
 ```xquery
-declare function file-upload:upload-text($request as map(*)) {
-  (: Get the file name from the URL path. :)
-  let $file-path as xs:string? := local:file-path($request?parameters?path)
-  (: Make a text node for serialization. :)
-  let $file-content as node() := text { $request?body?file }
-  let $stored as xs:boolean? :=
-    if (exists($file-path)) then
-      file:serialize-text($file-content, $file-path, ('method=text'))
-    else
-      util:log("error", ``[Cannot store uploaded text file of size `{string-length($file-content)}` without a correct file path]``)
-  return
-    if ($stored) then
-      let $log := util:log("info", ``[Stored uploaded text file of size `{string-length($file-content)}` into `{$file-path}`]``)
-      return
-        roaster:response(201, $stored)
-    else
-      roaster:response(400, $stored)
+declare function upload:single ($request as map(*)) {
+    let $filename as xs:string := $request?parameters?path
+    let $file as map(*) := $request?body?file[1]
+    let $stored as xs:boolean :=
+        xmldb:store('/db/apps/roasted/uploads', $filename, $file?data)
+
+    return roaster:response(201, map { "uploaded": $stored })
 };
 ```
 
-## Binary file upload
+This setup is able to handle XML, text as well as binary file uploads.
 
-Next is a binary file upload, which can be used for images and other data that does not fit in an `xs:string`.
-The HTML form:
+## Uploading multiple files
+
+In order to allow batch uploads only very few modifications to the above example for single file uploads have to made.
+
+1. Signal that more than one element is expected in api.json 
+   `"multipart/form-data".schema.properties.file` is now of type array
+    ```json
+    {
+        "type": "array",
+        "items": {
+            "type": "string",
+            "format": "binary"                    
+        }
+    }
+    ```
+2. `<input type="file" multiple="true" />`
+3. iterate over all files in the body `for $file in $request?body?file`
+4. return array of uploaded resources in response
 
 ```html
-    <form action="../upload-binary" method="POST" enctype="multipart/form-data" id="binaryFileUploadForm">
-      <fieldset>
-        <legend>Upload a binary file.</legend>
-        <p><input type="file" name="file" id="binaryFileUploadInput"/></p>
-        <p><input type="submit" value="Upload binary file"/></p>
-      </fieldset>
+    <form action="../upload/batch" method="POST" enctype="multipart/form-data">
+        <input type="file" name="file" multiple="true"/><br/>
+        <input type="submit" value="Upload files"/>
     </form>
 ```
 
-No javascript is needed, so let's move on to the OpenAPI specification.
-
 ```json
-        "/upload-binary": {
-            "post": {
-                "summary": "Upload a binary file.",
-                "description": "In this example, the file path is sent as binary form data.",
-                "operationId": "file-upload:upload-binary",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "file": { "type": "string", "format": "binary" }
+{
+    "/upload/batch": {
+        "post": {
+            "summary": "Upload a batch of files.",
+            "operationId": "upload:batch",
+            "requestBody": {
+                "required": true,
+                "content": {
+                    "multipart/form-data": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "file": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "format": "binary"                    
+                                    }
                                 }
                             }
                         }
                     }
-                },
-                "parameters": [],
-                "responses": {
-                    "201": {
-                        "description": "Created uploaded file",
-                        "content": {
-                            "application/json": {
-                                "schema": { "type": "string" }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Content was invalid",
-                        "content": {
-                            "application/json": {
-                                "schema": { "type": "string" }
-                            }
-                        }
-                    }
                 }
-            }
+            },
+            "responses": {}
         }
+    }
+}
 ```
-The corresponding XQuery function is `file-upload:upload-binary`.
 
 ```xquery
-declare function file-upload:upload-binary($request as map(*)) {
-  let $file-path as xs:string? := local:file-path(request:get-uploaded-file-name('file'))
-  let $file-content as xs:base64Binary := request:get-uploaded-file-data('file')
-  let $file-content-length as xs:double := request:get-uploaded-file-size('file')
-  let $stored as xs:boolean? :=
-    if (exists($file-path)) then
-      file:serialize-binary($file-content, $file-path)
-    else
-      util:log("error", ``[Cannot store uploaded binary file of size `{$file-content-length}` without a correct file path]``)
-  return
-    if ($stored) then
-      let $log := util:log("info", ``[Stored uploaded binary file of size `{$file-content-length}` into `{$file-path}`]``)
-      return
-        roaster:response(201, $stored)
-    else
-      roaster:response(400, $stored)
+declare function upload:batch ($request as map(*)) {
+    let $stored :=
+        array{
+            for $file in $request?body?file
+            return xmldb:store(
+                "/db/apps/roasted/uploads", $file?name, $file?data)
+        }
+
+    return roaster:response(201, map{ "uploaded": $stored })
 };
 ```
+
 
 ## Base64 encoded file upload
 
@@ -204,16 +195,14 @@ The previous example shows how to upload binary data unencoded, but since the Op
 The HTML form is similar to the one for binary upload, but includes a hidden `data` input for the encoded data.
 
 ```html
-    <form action="../upload-base64" method="POST" enctype="multipart/form-data" id="base64FileUploadForm"
-        onsubmit="return submitBase64FileUpload()"
+    <form action="../upload/base64" method="POST" enctype="multipart/form-data" id="base64FileUploadForm"
+        onsubmit="submitBase64FileUpload"
     >
-      <fieldset>
-        <legend>Upload a binary file encoded as base64.</legend>
-        <p><input type="file" name="file" id="base64FileUploadInput"/>
-          <!-- A hidden field is used for sending the base64 encoded data. -->
-          <input type="hidden" name="data" id="base64FileUploadData"/>
-        </p>
-        <p><input type="submit" value="Upload binary file as base64"/></p>
+        <input type="file" name="file" id="base64FileUploadInput"/>
+        <br/>
+        <input type="submit" value="Upload binary file as base64"/>
+        <!-- A hidden field is used for sending the base64 encoded data. -->
+        <input type="hidden" name="data" id="base64FileUploadData"/>
       </fieldset>
     </form>
 ```
@@ -221,84 +210,84 @@ The HTML form is similar to the one for binary upload, but includes a hidden `da
 Base64 encoding is not provided by the HTML form, so we need some javascript.
 
 ```javascript
-      function submitBase64FileUpload()
-      {
-        event.preventDefault();
-        const file = document.getElementById('base64FileUploadInput').files[0];
-        const reader = new FileReader();
-        reader.onloadend = function () {
-          // The reader makes a data: URI; remove the prefix and only keep the base64 string.
-          const base64 = reader.result.replace(/^data:.+;base64,/, '');
-          document.getElementById('base64FileUploadData').value = base64;
-          document.getElementById('base64FileUploadForm').submit();
-        };
-        reader.readAsDataURL(file);
-        // Return true to not submit, but wait for the reader to finish.
-        return false;
-      }
+function submitBase64FileUpload() {
+    event.preventDefault();
+    const file = document.getElementById('base64FileUploadInput').files[0];
+    const reader = new FileReader();
+    reader.onloadend = function () {
+        // The reader makes a data: URI; remove the prefix and only keep the base64 string.
+        const base64 = reader.result.replace(/^data:.+;base64,/, '');
+        document.getElementById('base64FileUploadData').value = base64;
+        document.getElementById('base64FileUploadForm').submit();
+    };
+    reader.readAsDataURL(file);
+    // do not submit, but wait for the reader to finish.
+    return false;
+}
 ```
 
 This time, the OpenAPI specification uses `"data": { "type": "string", "format": "base64" }`.
 
 ```json
-        "/upload-base64": {
-            "post": {
-                "summary": "Upload a binary file, which is encoded as base64.",
-                "operationId": "file-upload:upload-base64",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "data": { "type": "string", "format": "base64" }
+{
+    "/upload/base64": {
+        "post": {
+            "summary": "Upload a base64-encoded file.",
+            "operationId": "upload:base64",
+            "requestBody": {
+                "content": {
+                    "multipart/form-data": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "file": {
+                                    "type": "string",
+                                    "format": "binary"
+                                },
+                                "data": {
+                                    "type": "string",
+                                    "format": "base64"
                                 }
                             }
                         }
                     }
-                },
-                "parameters": [],
-                "responses": {
-                    "201": {
-                        "description": "Created uploaded file",
-                        "content": {
-                            "application/json": {
-                                "schema": { "type": "string" }
-                            }
+                }
+            },
+            "parameters": [],
+            "responses": {
+                "201": {
+                    "description": "Created uploaded file",
+                    "content": {
+                        "application/json": {
+                            "schema": { "type": "string" }
                         }
-                    },
-                    "400": {
-                        "description": "Content was invalid",
-                        "content": {
-                            "application/json": {
-                                "schema": { "type": "string" }
-                            }
+                    }
+                },
+                "400": {
+                    "description": "Content was invalid",
+                    "content": {
+                        "application/json": {
+                            "schema": { "type": "string" }
                         }
                     }
                 }
             }
         }
+    }
+}
 ```
 
-The `file` data is still present in the request, but we will not use it in the XQuery function.
+The `file` data is still present in the request, but we will not use its data but only its name.
 We could have removed it in the javascript, to save some precious bytes in the request body.
 
 ```xquery
-declare function file-upload:upload-base64($request as map(*)) {
-  let $file-path as xs:string? := local:file-path(request:get-uploaded-file-name('file'))
-  let $file-content as xs:base64Binary := xs:base64Binary($request?body?data)
-  let $file-content-length as xs:integer := string-length($request?body?data) * 3 idiv 4 (: approximately :)
-  let $stored as xs:boolean? :=
-    if (exists($file-path)) then
-      file:serialize-binary($file-content, $file-path)
-    else
-      util:log("error", ``[Cannot store uploaded binary file of size `{$file-content-length}` without a correct file path]``)
-  return
-    if ($stored) then
-      let $log := util:log("info", ``[Stored uploaded binary file of size `{$file-content-length}` into `{$file-path}`]``)
-      return
-        roaster:response(201, $stored)
-    else
-      roaster:response(400, $stored)
+declare function upload:base64 ($request as map(*)) {
+    let $file-name as xs:string := $request?body?file[1]?name
+    let $file-content as xs:base64Binary := $request?body?data
+    let $stored as xs:string :=
+        xmldb:store('/db/apps/roasted/uploads', $file-name, $file-content)
+
+    return
+        roaster:response(201, map{ 'uploaded': $stored })
 };
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "chai-openapi-response-validator": "^0.9.4",
         "delete": "^1.1.0",
         "dotenv-cli": "^4.0.0",
-        "form-data": "^3.0.0",
+        "form-data": "^3.0.1",
         "gulp": "^4.0.2",
         "gulp-rename": "^2.0.0",
         "gulp-zip": "^5.0.2",
@@ -3696,9 +3696,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -17554,9 +17554,9 @@
       }
     },
     "form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chai-openapi-response-validator": "^0.9.4",
     "delete": "^1.1.0",
     "dotenv-cli": "^4.0.0",
-    "form-data": "^3.0.0",
+    "form-data": "^3.0.1",
     "gulp": "^4.0.2",
     "gulp-rename": "^2.0.0",
     "gulp-zip": "^5.0.2",

--- a/test/app/api.json
+++ b/test/app/api.json
@@ -344,11 +344,14 @@
                     "content": {
                         "multipart/form-data": {
                             "schema": {
-                                "type": "array",
+                                "type": "object",
                                 "properties": {
                                   "file": {
-                                    "type": "string",
-                                    "format": "binary"
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "format": "binary"                    
+                                    }
                                   }
                                 }
                             }

--- a/test/app/api.json
+++ b/test/app/api.json
@@ -342,20 +342,6 @@
                 "requestBody": {
                     "required": true,
                     "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                  "file": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string",
-                                        "format": "binary"                    
-                                    }
-                                  }
-                                }
-                            }
-                        },
                         "*/*": {
                             "schema": {
                                 "type": "string",
@@ -398,6 +384,148 @@
                 }
             }
         },
+        "/upload/single/{path}": {
+            "post": {
+                "summary": "Upload a single file.",
+                "description": "In this example, the file path is part of the URL.",
+                "operationId": "upload:single",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "file": {
+                                        "type": "string",
+                                        "format": "binary"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "path",
+                        "in": "path",
+                        "required": true,
+                        "schema":{ "type": "string" }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created uploaded file",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "string" }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Content was invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/upload/batch": {
+            "post": {
+                "summary": "Upload a batch of files",
+                "operationId": "upload:batch",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "file": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "format": "binary"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [],
+                "responses": {
+                    "201": {
+                        "description": "Created uploaded file",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "uploaded": { "type": "array" }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Content was invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/upload/base64": {
+            "post": {
+                "summary": "Upload a base64-encoded file.",
+                "operationId": "upload:base64",
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "file": {
+                                        "type": "string",
+                                        "format": "binary"
+                                    },
+                                    "data": {
+                                        "type": "string",
+                                        "format": "base64"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [],
+                "responses": {
+                    "201": {
+                        "description": "Created uploaded file",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "string" }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Content was invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        },    
         "/api/$op-er+ation*!":{
             "get": {
                 "summary": "Get path using a $ character",

--- a/test/app/api.json
+++ b/test/app/api.json
@@ -342,6 +342,17 @@
                 "requestBody": {
                     "required": true,
                     "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "array",
+                                "properties": {
+                                  "file": {
+                                    "type": "string",
+                                    "format": "binary"
+                                  }
+                                }
+                            }
+                        },
                         "*/*": {
                             "schema": {
                                 "type": "string",

--- a/test/app/modules/api.xql
+++ b/test/app/modules/api.xql
@@ -68,15 +68,11 @@ declare function api:handle-error($error as map(*)) as element(html) {
 };
 
 declare function api:upload-data ($request as map(*)) {
-    if ($request?body instance of map(*) and $request?body?__multipart)
+    if ($request?body instance of map(*) and exists($request?body?file))
     then (
-        let $names := request:get-uploaded-file-name('file')
-        let $contents := request:get-uploaded-file-data('file')
-
         let $stored :=
-            for $name at $index in $names
-            let $content := $contents[$index]
-            return xmldb:store("/db/apps/roasted/uploads", $name, $content)
+            for $file in $request?body?file
+            return xmldb:store("/db/apps/roasted/uploads", $file?name, $file?data)
         return roaster:response(201, string-join($stored, '&#10;'))
     )
     else (

--- a/test/app/modules/api.xql
+++ b/test/app/modules/api.xql
@@ -10,6 +10,7 @@ import module namespace auth="http://e-editiones.org/roaster/auth";
 import module namespace rutil="http://e-editiones.org/roaster/util";
 import module namespace errors="http://e-editiones.org/roaster/errors";
 
+import module namespace upload="http://e-editiones.org/roasted/upload" at "upload.xqm";
 
 (:~
  : list of definition files to use
@@ -68,25 +69,16 @@ declare function api:handle-error($error as map(*)) as element(html) {
 };
 
 declare function api:upload-data ($request as map(*)) {
-    if ($request?body instance of map(*) and exists($request?body?file))
-    then (
-        let $stored :=
-            for $file in $request?body?file
-            return xmldb:store("/db/apps/roasted/uploads", $file?name, $file?data)
-        return roaster:response(201, string-join($stored, '&#10;'))
-    )
-    else (
-        let $body :=
-            if (
-                $request?body instance of array(*) or
-                $request?body instance of map(*)
-            )
-            then ($request?body => serialize(map { "method": "json" }))
-            else ($request?body)
+    let $body :=
+        if (
+            $request?body instance of array(*) or
+            $request?body instance of map(*)
+        )
+        then ($request?body => serialize(map { "method": "json" }))
+        else ($request?body)
 
-        let $stored := xmldb:store("/db/apps/roasted/uploads", $request?parameters?path, $body)
-        return roaster:response(201, $stored)
-    )
+    let $stored := xmldb:store("/db/apps/roasted/uploads", $request?parameters?path, $body)
+    return roaster:response(201, $stored)
 };
 
 declare function api:get-uploaded-data ($request as map(*)) {

--- a/test/app/modules/upload.xqm
+++ b/test/app/modules/upload.xqm
@@ -38,9 +38,9 @@ declare function upload:batch ($request as map(*)) {
 };
 
 declare function upload:base64 ($request as map(*)) {
-    let $file-name as xs:string := $request?body?file?name
+    let $file-name as xs:string := $request?body?file[1]?name
     let $file-content as xs:base64Binary := $request?body?data
-    let $stored as xs:boolean :=
+    let $stored as xs:string :=
         xmldb:store('/db/apps/roasted/uploads', $file-name, $file-content)
 
     return

--- a/test/app/modules/upload.xqm
+++ b/test/app/modules/upload.xqm
@@ -23,14 +23,12 @@ declare function upload:single ($request as map(*)) {
 
 declare function upload:batch ($request as map(*)) {
     try {
-        let $stored :=
-            array {
-                for $file in $request?body?file
-                return xmldb:store($upload:collection, $file?name, $file?data)
-            }
+        let $stored as xs:string+ :=
+            for $file in $request?body?file
+            return xmldb:store($upload:collection, $file?name, $file?data)
 
         return
-            roaster:response(201, map{ "uploaded": $stored })
+            roaster:response(201, map{ "uploaded": array{ $stored }})
     }
     catch * {
         roaster:response(400, map { "error": $err:description })        

--- a/test/app/modules/upload.xqm
+++ b/test/app/modules/upload.xqm
@@ -1,0 +1,48 @@
+xquery version "3.1";
+
+module namespace upload="http://e-editiones.org/roasted/upload";
+
+import module namespace roaster="http://e-editiones.org/roaster";
+
+declare variable $upload:collection := '/db/apps/roasted/uploads';
+
+declare function upload:single ($request as map(*)) {
+    try {
+        let $filename as xs:string := $request?parameters?path
+        let $file as map(*) := $request?body?file[1]
+        let $stored as xs:string :=
+            xmldb:store($upload:collection, $filename, $file?data)
+
+        return
+            roaster:response(201, map { "uploaded": $stored })
+    }
+    catch * {
+        roaster:response(400, map { "error": $err:description })        
+    }
+};
+
+declare function upload:batch ($request as map(*)) {
+    try {
+        let $stored :=
+            array {
+                for $file in $request?body?file
+                return xmldb:store($upload:collection, $file?name, $file?data)
+            }
+
+        return
+            roaster:response(201, map{ "uploaded": $stored })
+    }
+    catch * {
+        roaster:response(400, map { "error": $err:description })        
+    }
+};
+
+declare function upload:base64 ($request as map(*)) {
+    let $file-name as xs:string := $request?body?file?name
+    let $file-content as xs:base64Binary := $request?body?data
+    let $stored as xs:boolean :=
+        xmldb:store('/db/apps/roasted/uploads', $file-name, $file-content)
+
+    return
+        roaster:response(201, map{ 'uploaded': $stored })
+};

--- a/test/app/repo.xml
+++ b/test/app/repo.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<meta 
-  xmlns="http://exist-db.org/xquery/repo">
+<meta xmlns="http://exist-db.org/xquery/repo">
   <description>roasted - OpenAPI Router Test Application</description>
   <author>TEI Publisher Project Team</author>
   <website>https://github.com/eeditiones/roaster#readme</website>

--- a/test/app/resources/upload.html
+++ b/test/app/resources/upload.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <h1>Roaster File Upload Examples</h1>
+        <article>
+            <h2>Upload a single file.</h2>
+            <p>
+                In this example, the filename is part of the URL, so the form action is modified.
+                The filename is also sent in the form-data, so this is not really necessary.
+            </p>
+            <form name="singleFileUploadForm" 
+                action="#"
+                method="POST" 
+                enctype="multipart/form-data"
+                onsubmit="return uploadSingleFile(event)"
+            >
+                <input type="file" name="file" id="singleFileUploadInput"/>
+                <br/>
+                <input type="submit" value="Upload a single file"/>
+            </form>
+            <script>
+                function uploadSingleFile (event) {
+                    const input = document.getElementById('singleFileUploadInput')
+                    const fileName = input.files[0].name;
+
+                    const form = event.target
+                    form.action = `../upload/single/${fileName}`;
+                    // Return true to submit immediately.
+                    return true;
+                }
+            </script>
+        </article>
+
+        <article>
+            <h2>Upload multiple files</h2>
+            <p>
+                Since we upload one or more files the filename cannot be part of the URL.
+                Now, we need to use the filename(s) sent in the form-data.
+            </p>
+            <form action="../upload/batch" method="POST" enctype="multipart/form-data">
+                <input type="file" name="file" multiple="true"/><br/>
+                <input type="submit" value="Upload files"/>
+            </form>
+        </article>
+
+        <article>
+            <h2>Upload a file encoded as base64</h2>
+            <form action="../upload/base64" method="POST" 
+                enctype="multipart/form-data"
+                id="base64FileUploadForm"
+                onsubmit="submitBase64FileUpload">
+                <input type="file" name="file" id="base64FileUploadInput"/>
+                <br/>
+                <input type="submit" value="Upload binary file as base64"/>
+                <!-- A hidden field is used for sending the base64 encoded data. -->
+                <input type="hidden" name="data" id="base64FileUploadData"/>
+            </form>
+            <script>
+                function submitBase64FileUpload (event) {
+                    event.preventDefault();
+                    const input = document.getElementById('base64FileUploadInput')
+                    const file = input.files[0];
+                    const reader = new FileReader();
+                    
+                    reader.onloadend = function () {
+                        // The reader makes a data: URI; remove the prefix and only keep the base64 string.
+                        const base64 = reader.result.replace(/^data:.+;base64,/, '');
+                        document.getElementById('base64FileUploadData').value = base64;
+                        document.getElementById('base64FileUploadForm').submit();
+                    };
+                    reader.readAsDataURL(file);
+                    // Return true to not submit, but wait for the reader to finish.
+                    return false;
+                }
+            </script>
+        </article>
+    </body>
+</html>

--- a/test/mediatype.test.js
+++ b/test/mediatype.test.js
@@ -276,7 +276,7 @@ test.
 
         before(function () {
             return util.axios.post(
-                'api/paths/' + filename,
+                'upload/single/' + filename,
                 data,
                 { headers }                
             )
@@ -285,7 +285,8 @@ test.
         })
         it("is uploaded", function () {
             expect(uploadResponse.status).to.equal(201)
-            expect(uploadResponse.data).to.equal(dbUploadCollection + filename)
+            expect(uploadResponse.data.uploaded).to.exist
+            expect(uploadResponse.data.uploaded).to.equal(dbUploadCollection + filename)
         })
         it('can be retrieved', async function () {
             const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
@@ -316,7 +317,7 @@ test.
 
         before(function () {
             return util.axios.post(
-                'api/paths/' + filename,
+                'upload/single/' + filename,
                 data,
                 { headers }                
             )
@@ -325,7 +326,8 @@ test.
         })
         it("is uploaded", function () {
             expect(uploadResponse.status).to.equal(201)
-            expect(uploadResponse.data).to.equal(dbUploadCollection + filename)
+            expect(uploadResponse.data.uploaded).to.exist
+            expect(uploadResponse.data.uploaded).to.equal(dbUploadCollection + filename)
         })
         it('can be retrieved', async function () {
             const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
@@ -350,7 +352,7 @@ test.
 
         before(function () {
             return util.axios.post(
-                'api/paths/' + filename,
+                'upload/single/' + filename,
                 data,
                 { headers }                
             )
@@ -359,7 +361,8 @@ test.
         })
         it("is uploaded", function () {
             expect(uploadResponse.status).to.equal(201)
-            expect(uploadResponse.data).to.equal(dbUploadCollection + filename)
+            expect(uploadResponse.data.uploaded).to.exist
+            expect(uploadResponse.data.uploaded).to.equal(dbUploadCollection + filename)
         })
         it('can be retrieved', async function () {
             const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
@@ -392,7 +395,7 @@ test.
 
         before(function () {
             return util.axios.post(
-                'api/paths/batch',
+                'upload/batch',
                 data,
                 { headers }                
             )
@@ -401,10 +404,11 @@ test.
         })
         it("both were uploaded", function () {
             expect(uploadResponse.status).to.equal(201)
-            expect(uploadResponse.data).to.equal(
-              dbUploadCollection + firstFileName + '\n' +
-              dbUploadCollection + secondFileName
-            )
+            expect(uploadResponse.data.uploaded).to.exist
+            expect(uploadResponse.data.uploaded).to.deep.equal([
+                dbUploadCollection + firstFileName,
+                dbUploadCollection + secondFileName
+            ])
         })
         it('both can be retrieved', async function () {
             const res = await util.axios.get('api/paths/' + firstFileName, { responseType: 'arraybuffer' })

--- a/test/mediatype.test.js
+++ b/test/mediatype.test.js
@@ -5,6 +5,7 @@ const expect = chai.expect
 const fs = require('fs')
 const FormData = require('form-data')
 const dbUploadCollection = '/db/apps/roasted/uploads/'
+const downloadApiEndpoint = 'api/paths/'
 
 describe("Binary up and download", function () {
     const contents = fs.readFileSync("./dist/roasted.xar")
@@ -22,7 +23,7 @@ describe("Binary up and download", function () {
             expect(res.data).to.equal(dbUploadCollection + filename)
         })
         it('retrieves the data', async function () {
-            const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
+            const res = await util.axios.get(downloadApiEndpoint + filename, { responseType: 'arraybuffer' })
             expect(res.status).to.equal(200)
             expect(res.data).to.eql(contents)
         })
@@ -45,7 +46,7 @@ describe("Binary up and download", function () {
             expect(res.data).to.equal(dbUploadCollection + filename)
         })
         it('retrieves the data', async function () {
-            const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
+            const res = await util.axios.get(downloadApiEndpoint + filename, { responseType: 'arraybuffer' })
             expect(res.status).to.equal(200)
             expect(res.data).to.eql(contents)
         })
@@ -79,7 +80,7 @@ describe("body with content-type application/xml", function () {
             expect(uploadResponse.data).to.equal(dbUploadCollection + filename)
         })
         it('can be retrieved', async function () {
-            const {status, data} = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
+            const {status, data} = await util.axios.get(downloadApiEndpoint + filename, { responseType: 'arraybuffer' })
             expect(status).to.equal(200)
             expect(data).to.eql(contents)
         })
@@ -109,7 +110,7 @@ describe("body with content-type application/xml", function () {
             expect(uploadResponse.data).to.equal(dbUploadCollection + filename)
         })
         it('can is stored encoded in UTF-8 and normalized', async function () {
-            const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
+            const res = await util.axios.get(downloadApiEndpoint + filename, { responseType: 'arraybuffer' })
             expect(res.status).to.equal(200)
             expect(res.data.toString('utf-8')).to.equal(dbNormalizedValue)
         })
@@ -163,7 +164,7 @@ describe("body with content-type application/tei+xml", function () {
             expect(uploadResponse.data).to.equal(dbUploadCollection + filename)
         })
         it('can be retrieved', async function () {
-            const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
+            const res = await util.axios.get(downloadApiEndpoint + filename, { responseType: 'arraybuffer' })
             expect(res.status).to.equal(200)
             expect(res.data).to.eql(contents)
         })
@@ -215,7 +216,7 @@ describe("body with content-type application/json", function () {
             expect(uploadResponse.data).to.equal(dbUploadCollection + filename)
         })
         it('can be retrieved', async function () {
-            const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
+            const res = await util.axios.get(downloadApiEndpoint + filename, { responseType: 'arraybuffer' })
             expect(res.status).to.equal(200)
             expect(res.data).to.eql(contents)
         })
@@ -286,10 +287,10 @@ test.
         it("is uploaded", function () {
             expect(uploadResponse.status).to.equal(201)
             expect(uploadResponse.data.uploaded).to.exist
-            expect(uploadResponse.data.uploaded).to.equal(dbUploadCollection + filename)
+            expect(uploadResponse.data.uploaded).to.equal(downloadApiEndpoint + filename)
         })
         it('can be retrieved', async function () {
-            const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
+            const res = await util.axios.get(uploadResponse.data.uploaded, { responseType: 'arraybuffer' })
             expect(res.status).to.equal(200)
             expect(res.data).to.eql(contents)
         })
@@ -327,10 +328,10 @@ test.
         it("is uploaded", function () {
             expect(uploadResponse.status).to.equal(201)
             expect(uploadResponse.data.uploaded).to.exist
-            expect(uploadResponse.data.uploaded).to.equal(dbUploadCollection + filename)
+            expect(uploadResponse.data.uploaded).to.equal(downloadApiEndpoint + filename)
         })
         it('can be retrieved', async function () {
-            const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
+            const res = await util.axios.get(uploadResponse.data.uploaded, { responseType: 'arraybuffer' })
             expect(res.status).to.equal(200)
             expect(res.data.toString()).to.eql(contents.toString())
         })
@@ -362,10 +363,10 @@ test.
         it("is uploaded", function () {
             expect(uploadResponse.status).to.equal(201)
             expect(uploadResponse.data.uploaded).to.exist
-            expect(uploadResponse.data.uploaded).to.equal(dbUploadCollection + filename)
+            expect(uploadResponse.data.uploaded).to.equal(downloadApiEndpoint + filename)
         })
         it('can be retrieved', async function () {
-            const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
+            const res = await util.axios.get(uploadResponse.data.uploaded, { responseType: 'arraybuffer' })
             expect(res.status).to.equal(200)
             expect(res.data.length).to.eql(contents.length)
         })
@@ -406,16 +407,16 @@ test.
             expect(uploadResponse.status).to.equal(201)
             expect(uploadResponse.data.uploaded).to.exist
             expect(uploadResponse.data.uploaded).to.deep.equal([
-                dbUploadCollection + firstFileName,
-                dbUploadCollection + secondFileName
+                downloadApiEndpoint + firstFileName,
+                downloadApiEndpoint + secondFileName
             ])
         })
         it('both can be retrieved', async function () {
-            const res = await util.axios.get('api/paths/' + firstFileName, { responseType: 'arraybuffer' })
+            const res = await util.axios.get(uploadResponse.data.uploaded[0], { responseType: 'arraybuffer' })
             expect(res.status).to.equal(200)
             expect(res.data.toString()).to.eql(firstFileContent, 'Contents of first file differs')
 
-            const secondRes = await util.axios.get('api/paths/' + secondFileName, { responseType: 'arraybuffer' })
+            const secondRes = await util.axios.get(uploadResponse.data.uploaded[1], { responseType: 'arraybuffer' })
             expect(secondRes.status).to.equal(200)
             expect(secondRes.data.toString()).to.eql(secondFileContent, 'Second of first file differs')
         })
@@ -447,10 +448,10 @@ test.
         it("was uploaded", function () {
             expect(uploadResponse.status).to.equal(201)
             expect(uploadResponse.data.uploaded).to.exist
-            expect(uploadResponse.data.uploaded).to.equal(dbUploadCollection + fileName)
+            expect(uploadResponse.data.uploaded).to.equal(downloadApiEndpoint + fileName)
         })
         it('can be retrieved', async function () {
-            const res = await util.axios.get('api/paths/' + fileName, { responseType: 'arraybuffer' })
+            const res = await util.axios.get(uploadResponse.data.uploaded, { responseType: 'arraybuffer' })
             expect(res.status).to.equal(200)
             expect(res.data).to.eql(fileContent, 'Content of file does not match')
         })
@@ -483,10 +484,10 @@ test.
         it("was uploaded", function () {
             expect(uploadResponse.status).to.equal(201)
             expect(uploadResponse.data.uploaded).to.exist
-            expect(uploadResponse.data.uploaded).to.equal(dbUploadCollection + dbResourceName)
+            expect(uploadResponse.data.uploaded).to.equal(downloadApiEndpoint + dbResourceName)
         })
         it('can be retrieved', async function () {
-            const res = await util.axios.get('api/paths/' + dbResourceName, { responseType: 'arraybuffer' })
+            const res = await util.axios.get(uploadResponse.data.uploaded, { responseType: 'arraybuffer' })
             // console.log(res)
             expect(res.status).to.equal(200)
             expect(res.data.toString()).to.equal(fileContent.toString())
@@ -521,10 +522,10 @@ test.
         it("was uploaded", function () {
             expect(uploadResponse.status).to.equal(201)
             expect(uploadResponse.data.uploaded).to.exist
-            expect(uploadResponse.data.uploaded).to.equal(dbUploadCollection + filename)
+            expect(uploadResponse.data.uploaded).to.equal(downloadApiEndpoint + filename)
         })
         it('can be retrieved', async function () {
-            const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
+            const res = await util.axios.get(uploadResponse.data.uploaded, { responseType: 'arraybuffer' })
             expect(res.status).to.equal(200)
             expect(res.data.toString()).to.eql(fileContent.toString(), 'Content of file does not match')
         })

--- a/test/mediatype.test.js
+++ b/test/mediatype.test.js
@@ -421,6 +421,115 @@ test.
         })
     })
 
+    describe("text sent base64 encoded", function () {
+        let uploadResponse
+        const data = new FormData()
+
+        const fileName = 'sent-base64-encoded.txt'
+        const fileContent = Buffer.from('first text')
+        data.append('file', fileContent, {
+            knownLength: fileContent.length,
+            filename: fileName,
+            contentType: 'application/octet-stream'
+        })
+        data.append('data', fileContent.toString('base64'))
+        const headers = data.getHeaders();
+
+        before(function () {
+            return util.axios.post(
+                'upload/base64',
+                data,
+                { headers }                
+            )
+            .then(r => uploadResponse = r)
+            .catch(e => uploadResponse = e.response )
+        })
+        it("was uploaded", function () {
+            expect(uploadResponse.status).to.equal(201)
+            expect(uploadResponse.data.uploaded).to.exist
+            expect(uploadResponse.data.uploaded).to.equal(dbUploadCollection + fileName)
+        })
+        it('can be retrieved', async function () {
+            const res = await util.axios.get('api/paths/' + fileName, { responseType: 'arraybuffer' })
+            expect(res.status).to.equal(200)
+            expect(res.data).to.eql(fileContent, 'Content of file does not match')
+        })
+    })
+
+    // there is an issue with uploading binary data encoded as base64
+    describe("png sent base64 encoded", function () {
+        let uploadResponse
+        const data = new FormData()
+
+        const dbResourceName = 'roaster-router-logo-base64.png'
+        const fileContent = fs.readFileSync('test/app/resources/roaster-router-logo.png')
+        data.append('file', fileContent, {
+            knownLength: fileContent.length,
+            filename: dbResourceName,
+            contentType: 'image/png'
+        })
+        data.append('data', fileContent.toString('base64'))
+        const headers = data.getHeaders()
+
+        before(function () {
+            return util.axios.post(
+                'upload/base64',
+                data,
+                { headers }                
+            )
+            .then(r => uploadResponse = r)
+            .catch(e => uploadResponse = e.response )
+        })
+        it("was uploaded", function () {
+            expect(uploadResponse.status).to.equal(201)
+            expect(uploadResponse.data.uploaded).to.exist
+            expect(uploadResponse.data.uploaded).to.equal(dbUploadCollection + dbResourceName)
+        })
+        it('can be retrieved', async function () {
+            const res = await util.axios.get('api/paths/' + dbResourceName, { responseType: 'arraybuffer' })
+            // console.log(res)
+            expect(res.status).to.equal(200)
+            expect(res.data.toString()).to.equal(fileContent.toString())
+        })
+    })
+
+    describe("xml sent base64 encoded", function () {
+        let uploadResponse
+        const data = new FormData()
+
+        const filename = 'sent-base64-encoded.xml'
+        const fileContent = Buffer.from(`<root>
+    <nested/>
+</root>`)
+        data.append('file', fileContent, {
+            knownLength: fileContent.length,
+            filename,
+            contentType: 'application/octet-stream'
+        })
+        data.append('data', fileContent.toString('base64'))
+        const headers = data.getHeaders()
+
+        before(function () {
+            return util.axios.post(
+                'upload/base64',
+                data,
+                { headers }                
+            )
+            .then(r => uploadResponse = r)
+            .catch(e => uploadResponse = e.response )
+        })
+        it("was uploaded", function () {
+            expect(uploadResponse.status).to.equal(201)
+            expect(uploadResponse.data.uploaded).to.exist
+            expect(uploadResponse.data.uploaded).to.equal(dbUploadCollection + filename)
+        })
+        it('can be retrieved', async function () {
+            const res = await util.axios.get('api/paths/' + filename, { responseType: 'arraybuffer' })
+            expect(res.status).to.equal(200)
+            expect(res.data.toString()).to.eql(fileContent.toString(), 'Content of file does not match')
+        })
+    })
+
 })
 
 describe("with invalid content-type header", function () {


### PR DESCRIPTION
This PR adds proper form-data handling to roaster.
Both media types `application/x-www-urlencoded` and `multipart/form-data` are supported.
Each property defined in the schema of a requestBody spec will be parsed.
Route handler functions receive a body as a `map(propertyName as xs:string, propertyValue item())`.

This allows for to work with HTML forms default submissions including single and multi-file uploads.

Added tests for a variety of use-cases.

Example function to handle multi-file uploads

```xquery
declare function upload:batch ($request as map(*)) {
    try {
        let $stored as xs:string+ :=
            for $file in $request?body?file
            return xmldb:store($upload:collection, $file?name, $file?data)

        return
            roaster:response(201, map{ "uploaded": array{ $stored }})
    }
    catch * {
        roaster:response(400, map { "error": $err:description })        
    }
};
```