### PR TITLE
fix(request): some json bodies are strings

### DIFF
--- a/content/router.xql
+++ b/content/router.xql
@@ -394,10 +394,15 @@ declare function router:body ($request as map(*)) {
                 Parse body contents to XQuery data structure for media types
                 that were identified as being in JSON format.
                 NOTE: The data needs to be serialized again before it can be stored.
+                NOTE: For application/json-patch+json request:get-data returns an xs:string.
             :)
             case "json" return
-                request:get-data() 
-                => util:binary-to-string()
+                let $data := request:get-data()
+                return
+                    typeswitch($data)
+                    case xs:string return parse-json($data)
+                    default return
+                        util:binary-to-string($data)
                 => parse-json()
             (: 
                 Workaround for eXist-DB specific behaviour, 


### PR DESCRIPTION
fixes #47

While `request:get-data()` returns `xs:base64Binary` for request bodies encoded as `application/json` it returns and instance of `xs:string` for `application/json-patch+json`. In order for both to be parsed correctly a typeswitch is now in place.