### PR TITLE
fix(body): XML includes the document-node

### DIFF
--- a/content/body.xqm
+++ b/content/body.xqm
@@ -58,7 +58,7 @@ declare function body:parse ($request as map(*)) {
                 let $data := request:get-data()
                 return
                     typeswitch ($data)
-                    case node() return $data/node()
+                    case node() return $data
                     default return parse-xml($data)
             (: Treat everything else as binary data :)
             default return request:get-data()


### PR DESCRIPTION
Ensure items appearinge before and after the root element, such as processing instructions or comments are preserved.