### PR TITLE
feat(log): allow to pass in custom loggers

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
           - exist-version: latest
             experimental: true
     services:
-      roaster-test-db:
+      existdb:
         image: existdb/existdb:${{ matrix.exist-version }}
         ports:
           - 8443:8443
@@ -34,6 +34,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run tests
+        env:
+          EXISTDB_CONTAINER_NAME: ${{ job.services.existdb.id }}
         run: npm test
   release:
     name: Release

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Test and Release
 
 on: [push, pull_request]
@@ -19,7 +16,7 @@ jobs:
           - exist-version: latest
             experimental: true
     services:
-      exist:
+      roaster-test-db:
         image: existdb/existdb:${{ matrix.exist-version }}
         ports:
           - 8443:8443

--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ declare function custom-router:use-beep-boop ($request as map(*), $response as m
 Roaster transparently handles data from multipart/form-data requests to keep route handlers short and readable.
 Please see the [file upload documentation](doc/file-upload.md) for more details on this.
 
+## Logging
+
+Roaster allows to pass in a fourth parameter to `roaster:route#4`.
+It defaults to using util:log as before.
+
 ## Limitations
 
 The library does not support yet support following OpenAPI feature(s): 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,15 @@ This included the test application in `test/app`.
 
 To run the local test suite you need an instance of eXist running on `localhost:8080` and `npm` to be available in your path. To test against a different different server, or use a different user or password you can copy `.env.example` to `.env` and edit it to your needs.
 
-Run the test suite with
+There is a testsuite that will only work if you are running existdb in a docker container named "roater-test-db". This is also the name of the service started in CI.
+
+So a normal setup to test on your local machine is
+
+```sh
+docker run --name roaster-test-db -p 8443:8443 -p 8080:8080 existdb/existdb:6.4.0
+```
+
+And then run the test suite with
 
 ```shell
 npm test

--- a/README.md
+++ b/README.md
@@ -194,6 +194,30 @@ Please see the [file upload documentation](doc/file-upload.md) for more details 
 Roaster allows to pass in a fourth parameter to `roaster:route#4`.
 It defaults to using util:log as before.
 
+All route handlers will receive a reference to that logging function.
+
+```xquery
+declare function my:log($level as xs:string, $data as item()*) as empty-sequence() {
+    util:log-system-out(
+        upper-case($level) || " " || 
+        serialize($data, map{ "method": "adaptive" }))
+};
+```
+
+A custom logging function must expect two parameters:
+
+- The $level with the possible values 'trace', 'debug', 'info', 'warn', and 'error'
+- $data is a sequence of items, you might want to serialize it to your needs
+
+```xquery
+roaster:route(
+    $my:api,
+    my:lookup#1,
+    $my:middlewares,
+    my:log#2
+)
+```
+
 ## Limitations
 
 The library does not support yet support following OpenAPI feature(s): 

--- a/content/body.xqm
+++ b/content/body.xqm
@@ -130,7 +130,7 @@ declare function body:content-type ($request as map(*)) as map(*) {
             else error(
                 $errors:BODY_CONTENT_TYPE,
                 "Body with media-type '" || $media-type || "' is not allowed", 
-                $request
+                map:remove($request, 'logger')
             )
     )
 };

--- a/content/roaster.xqm
+++ b/content/roaster.xqm
@@ -77,11 +77,24 @@ declare function roaster:resolve-pointer ($config as map(*), $ref as xs:string*)
  : 3. If two paths have the same (normalized) length, prioritize by appearance in API files, first one wins
  :)
 declare function roaster:route($api-files as xs:string+, $lookup as function(xs:string) as function(*)?) {
-    router:route($api-files, $lookup, auth:standard-authorization#2)
+    router:route($api-files, $lookup, auth:standard-authorization#2, util:log#2)
 };
 
-declare function roaster:route($api-files as xs:string+, $lookup as function(xs:string) as function(*)?, $middleware) {
-    router:route($api-files, $lookup, $middleware)
+declare function roaster:route(
+    $api-files as xs:string+,
+    $lookup as function(xs:string) as function(*)?,
+    $middleware as (function(map(*), map(*)) as map(*)+)*
+) {
+    router:route($api-files, $lookup, $middleware, util:log#2)
+};
+
+declare function roaster:route(
+    $api-files as xs:string+,
+    $lookup as function(xs:string) as function(*)?,
+    $middleware as (function(map(*), map(*)) as map(*)+)*,
+    $logger as function(xs:string, item()*) as empty-sequence()
+) {
+    router:route($api-files, $lookup, $middleware, $logger)
 };
 
 declare function roaster:accepted-content-types () as xs:string* {

--- a/content/router.xql
+++ b/content/router.xql
@@ -89,7 +89,8 @@ declare function router:route (
     let $request-data := map { 
         "id": util:uuid(),
         "method": request:get-method() => lower-case(),
-        "path": request:get-attribute("$exist:path")
+        "path": request:get-attribute("$exist:path"),
+        "logger": $logger
     }
 
     return (

--- a/content/util.xql
+++ b/content/util.xql
@@ -46,5 +46,5 @@ declare function rutil:getDBUser() as map(*) {
  : to handler functions.
  :)
 declare function rutil:debug($request as map(*)) {
-    router:response(200, "application/json", $request, ())
+    router:response(200, "application/json", map:remove($request, 'logger'), ())
 };

--- a/test/app/modules/custom-router.xq
+++ b/test/app/modules/custom-router.xq
@@ -66,4 +66,14 @@ declare variable $custom-router:use := (
     custom-router:use-beep-boop#2
 );
 
-roaster:route($custom-router:definitions, custom-router:lookup#1, $custom-router:use)
+declare function custom-router:log-std ($level as xs:string, $message as item()*) as empty-sequence() {
+    switch(lower-case($level))
+    case 'error' return util:log-system-err($message)
+    default return util:log-system-out($message)
+};
+
+declare function custom-router:log-app ($level as xs:string, $message as item()*) as empty-sequence() {
+    util:log-app($level, "custom.log", $message)
+};
+
+roaster:route($custom-router:definitions, custom-router:lookup#1, $custom-router:use, custom-router:log-std#2)

--- a/test/app/modules/custom-router.xq
+++ b/test/app/modules/custom-router.xq
@@ -66,14 +66,28 @@ declare variable $custom-router:use := (
     custom-router:use-beep-boop#2
 );
 
+(:~
+ : Example of a custom logger that will output to standarad out and standard error depending on level
+ : This logger is also used for testing
+ :)
 declare function custom-router:log-std ($level as xs:string, $message as item()*) as empty-sequence() {
     switch(lower-case($level))
-    case 'error' return util:log-system-err($message)
-    default return util:log-system-out($message)
+    case 'error' return util:log-system-err(``[`{upper-case($level)}` `{$message}`]``)
+    default return util:log-system-out(``[`{upper-case($level)}` `{$message}`]``)
 };
 
+(:~
+ : Example of a custom logger application logger.
+ : While this offers greater flexiblity, additional changes need to be made to the log4j configuration
+ : of the exist-db instance the application will be running on.
+ :)
 declare function custom-router:log-app ($level as xs:string, $message as item()*) as empty-sequence() {
-    util:log-app($level, "custom.log", $message)
+    util:log-app($level, "roasted.app.logger", $message)
 };
 
-roaster:route($custom-router:definitions, custom-router:lookup#1, $custom-router:use, custom-router:log-std#2)
+roaster:route(
+    $custom-router:definitions,
+    custom-router:lookup#1,
+    $custom-router:use,
+    custom-router:log-std#2
+)

--- a/test/app/modules/custom-router.xq
+++ b/test/app/modules/custom-router.xq
@@ -71,9 +71,14 @@ declare variable $custom-router:use := (
  : This logger is also used for testing
  :)
 declare function custom-router:log-std ($level as xs:string, $message as item()*) as empty-sequence() {
-    switch(lower-case($level))
-    case 'error' return util:log-system-err(``[`{upper-case($level)}` `{$message}`]``)
-    default return util:log-system-out(``[`{upper-case($level)}` `{$message}`]``)
+    let $norm-level := upper-case($level)
+    let $serialized := serialize($message, map{"method": "adaptive"})
+    let $log-function :=
+        switch($norm-level)
+            case 'ERROR' return util:log-system-err#1
+            default return util:log-system-out#1
+
+    return $log-function(``[`{$norm-level}` `{$serialized}`]``)
 };
 
 (:~

--- a/test/app/modules/jwt-auth.xqm
+++ b/test/app/modules/jwt-auth.xqm
@@ -51,6 +51,7 @@ declare function jwt-auth:issue-token ($request as map(*)) {
         return
             if ($loggedin and $username = $user?name)
             then (
+                $request?logger('info', ``[[`{$request?id}`] New token issued for `{$username}`]``),
                 router:response(201, (), map {
                     "user": $user,
                     "token": $jwt-auth:jwt?create($user)

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -393,7 +393,7 @@ describe('sending more than one value for a non-array parameter', function () {
     })
 
     it('the error description starts with an actionable message', async function () {
-        console.log(message)
+        // console.log(message)
         expect(message.startsWith('Multiple values were provided for query-parameter "string", which is not declared an array')).to.be.true
     })
 })

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -1,6 +1,13 @@
-const util = require('./util.js');
+const { promisify } = require('node:util');
+const child_process = require('node:child_process');
+const exec = promisify(child_process.exec);
+
 const chai = require('chai');
 const expect = chai.expect;
+
+const util = require('./util.js');
+
+const dockerTestInstanceName = 'roaster-test-db'
 
 describe('public route with custom middleware', function () {
     const pathParameter = '1/2/this/is/just/a/test'
@@ -192,3 +199,52 @@ describe("requesting a token as guest", function () {
     
     })
 });
+
+describe("when using a custom logger that outputs to stdout and stderr", function () {
+    let standardOut, standardError
+
+    function filterLogs (output, match) {
+        return output.split('\n')
+            .filter(l => l.startsWith(match))
+    }
+
+    before(async function () {
+        // request route that logs
+        await util.axios.post('jwt/token', util.adminCredentials)
+                // read docker logs
+        const {stdout, stderr } = await exec(`docker logs ${dockerTestInstanceName}`)
+        standardOut = stdout
+        standardError = stderr
+    })
+
+    it('stdout and stderr were read from docker', function () {
+        expect(standardOut).to.exist
+        expect(standardError).to.exist
+    })
+
+    describe("the custom logs", function () {
+        let customOut, customErr
+
+        before(async function () {
+            // filter docker logs
+            customOut = filterLogs(standardOut, '(Line: 76 /db/apps/roasted/modules/custom-router.xq)')
+            customErr = filterLogs(standardError, '(Line: 75 /db/apps/roasted/modules/custom-router.xq) ERROR ')
+        })
+
+
+        it('debug messages can be found in stdout', function () {
+            expect(customOut.length).greaterThan(0)
+        })
+        it('error messages can be found in stderr', function () {
+            expect(customErr.length).greaterThan(0)
+        })
+        it('has log messages emitted from a route handler', function () {
+            const adminTokenIssued = customOut.filter(l => {
+                // console.log(l, l.endsWith('New token issued for admin'))
+                return l.endsWith('New token issued for admin')
+            })
+            console.log(adminTokenIssued)
+            expect(adminTokenIssued.length).to.be.greaterThan(0)
+        })
+    })
+})

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 
 const util = require('./util.js');
 
-const dockerTestInstanceName = 'roaster-test-db'
+const dockerTestInstanceName = process.env.EXISTDB_CONTAINER_NAME ?? 'roaster-test-db'
 
 describe('public route with custom middleware', function () {
     const pathParameter = '1/2/this/is/just/a/test'
@@ -239,11 +239,7 @@ describe("when using a custom logger that outputs to stdout and stderr", functio
             expect(customErr.length).greaterThan(0)
         })
         it('has log messages emitted from a route handler', function () {
-            const adminTokenIssued = customOut.filter(l => {
-                // console.log(l, l.endsWith('New token issued for admin'))
-                return l.endsWith('New token issued for admin')
-            })
-            console.log(adminTokenIssued)
+            const adminTokenIssued = customOut.filter(l => l.endsWith('New token issued for admin'))
             expect(adminTokenIssued.length).to.be.greaterThan(0)
         })
     })

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -211,8 +211,8 @@ describe("when using a custom logger that outputs to stdout and stderr", functio
     before(async function () {
         // request route that logs
         await util.axios.post('jwt/token', util.adminCredentials)
-                // read docker logs
-        const {stdout, stderr } = await exec(`docker logs ${dockerTestInstanceName}`)
+        // read docker logs
+        const { stdout, stderr } = await exec(`docker logs ${dockerTestInstanceName}`)
         standardOut = stdout
         standardError = stderr
     })
@@ -227,8 +227,8 @@ describe("when using a custom logger that outputs to stdout and stderr", functio
 
         before(async function () {
             // filter docker logs
-            customOut = filterLogs(standardOut, '(Line: 76 /db/apps/roasted/modules/custom-router.xq)')
-            customErr = filterLogs(standardError, '(Line: 75 /db/apps/roasted/modules/custom-router.xq) ERROR ')
+            customOut = filterLogs(standardOut, '(Line: -1 /db/apps/roasted/modules/custom-router.xq)')
+            customErr = filterLogs(standardError, '(Line: -1 /db/apps/roasted/modules/custom-router.xq) ERROR ')
         })
 
 
@@ -239,7 +239,7 @@ describe("when using a custom logger that outputs to stdout and stderr", functio
             expect(customErr.length).greaterThan(0)
         })
         it('has log messages emitted from a route handler', function () {
-            const adminTokenIssued = customOut.filter(l => l.endsWith('New token issued for admin'))
+            const adminTokenIssued = customOut.filter(l => l.endsWith('New token issued for admin"'))
             expect(adminTokenIssued.length).to.be.greaterThan(0)
         })
     })

--- a/test/mediatype.test.js
+++ b/test/mediatype.test.js
@@ -703,19 +703,21 @@ test.
 
 describe("with invalid content-type header", function () {
     let uploadResponse
-    before(function () {
-        return util.axios.post(
-            'api/paths/invalid.stuff',
-            'asd;lfkjdas;flkja',
-            {
-                headers: { 
-                    'Content-Type': 'my/thing',
-                    'Authorization': 'Basic YWRtaW46'
+    before(async function () {
+        try {
+            uploadResponse = await util.axios.post(
+                'api/paths/invalid.stuff',
+                'asd;lfkjdas;flkja',
+                {
+                    headers: {
+                        'Content-Type': 'my/thing',
+                        'Authorization': 'Basic YWRtaW46'
+                    }
                 }
-            }
-        )
-        .then(r => uploadResponse = r)
-        .catch(e => uploadResponse = e.response)
+            )
+        } catch (e) {
+            return uploadResponse = e.response
+        }
     })
     it("is rejected as Bad Request", function () {
         expect(uploadResponse.status).to.equal(400)


### PR DESCRIPTION
Add new function signature roaster:route#4 allowing to pass in a custom log function.
This allows for control what is logged where and how.

## Log to stdout and stderr

```xquery
declare function custom-router:log-std ($level as xs:string, $message as item()*) as empty-sequence() {
    switch(lower-case($level))
    case 'error' return util:log-system-err($message)
    default return util:log-system-out($message)
};
roaster:route($custom-router:definitions, custom-router:lookup#1, $custom-router:use, custom-router:log-std#2)
```

## Log using `util:log-app`

```xquery
declare function custom-router:log-app ($level as xs:string, $message as item()*) as empty-sequence() {
    util:log-app($level, "custom.log", $message)
};
roaster:route($custom-router:definitions, custom-router:lookup#1, $custom-router:use, custom-router:log-app#2)
```

For the above to work the logger needs to be added to log4j2.xml

```xml
<Logger name="custom.log" additivity="false" level="debug">
    <AppenderRef ref="exist.core"/><!-- or choose a different appender that you added -->
</Logger>
```

## update

The request map now has a logger property that is a reference to the function that roaster uses to log its messages.
This allows any route handler to also log to that output.

```xquery
declare function my:route ($request) {
    $request?log('info', 'my:route was called.'),
    "Hello World!"
};
```

That does also apply to middlewares

```xquery
declare function my:middleware ($request, $response) {
    $request?log('info', 'my:middleware was called.'),
    $request,
    $response
};
```