### PR TITLE
Path parameter encoding

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,9 +8,16 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: true
       matrix:
-        exist-version: [latest, release, 5.5.1]
+        exist-version: [release, 6.0.1, 5.5.1]
+        experimental: [false]
+        # latest might contain breaking changes
+        include:
+          - exist-version: latest
+            experimental: true
     services:
       exist:
         image: existdb/existdb:${{ matrix.exist-version }}

--- a/content/parameters.xql
+++ b/content/parameters.xql
@@ -47,6 +47,7 @@ declare function parameters:in-path ($request as map(*), $response as map(*)) as
                     then (
                         let $value :=
                             $match-path//fn:group[@nr=$pos]/string()
+                            => xmldb:decode()
                             => parameters:cast($path-param-map?($key))
 
                         return map { $key : $value }

--- a/test/app/api.json
+++ b/test/app/api.json
@@ -469,6 +469,35 @@
                 }
             }
         },
+        "/api/{test}/test":{
+            "get": {
+                "summary": "Get path with a fixed ending",
+                "operationId": "rutil:debug",
+                "tags": ["path"],
+                "parameters": [
+                    {
+                        "name": "test",
+                        "in": "path",
+                        "required": true,
+                        "schema":{
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200":{
+                        "description": "JSON dump of request",
+                        "content": {
+                            "application/json": {
+                                "schema":{
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/errors": {
             "get": {
                 "summary": "Reports an error via fn:error function",

--- a/test/paths.test.js
+++ b/test/paths.test.js
@@ -190,3 +190,20 @@ describe('Query parameters', function () {
         expect(res.data).to.be.true
     })
 })
+
+describe('with percent encoded value in path', function () {
+    const url = 'api/test%20and%20test/test'
+    let res
+
+    before(async function () {
+        res = await util.axios.get(url)
+    })
+
+    it('URL + "' + url + '" resolves', async function () {
+        expect(res.status).to.equal(200)
+    })
+
+    it('passes query parameters in GET', async function () {
+        expect(res.data.parameters.test).to.equal('test and test')
+    })
+})

--- a/test/paths.test.js
+++ b/test/paths.test.js
@@ -124,55 +124,59 @@ describe('Request body', function() {
 });
 
 describe('Query parameters', function () {
+    const params = {
+        'num': 165.75,
+        'int': 776,
+        'bool': true,
+        'string': '&a=2 2'
+    }
+    const headers = {
+        "X-start": 22
+    }
+
+
     it('passes query parameters in GET', async function () {
         const res = await util.axios.get('api/parameters', {
-            params: {
-                num: 165.75,
-                int: 776,
-                bool: true,
-                string: '&a=22'
-            },
-            headers: {
-                "X-start": 22
-            }
+            params,
+            headers
         })
         expect(res.status).to.equal(200)
         expect(res.data.parameters.num).to.be.a('number')
-        expect(res.data.parameters.num).to.equal(165.75)
+        expect(res.data.parameters.num).to.equal(params.num)
         expect(res.data.parameters.bool).to.be.a('boolean')
-        expect(res.data.parameters.bool).to.be.true
+        expect(res.data.parameters.bool).to.equal(params.bool)
         expect(res.data.parameters.int).to.be.a('number')
-        expect(res.data.parameters.int).to.equal(776)
-        expect(res.data.parameters.string).to.equal('&a=22')
+        expect(res.data.parameters.int).to.equal(params.int)
+        expect(res.data.parameters.string).to.equal(params.string)
+
+        expect(res.data.parameters['X-start']).to.equal(headers['X-start'])
+
         expect(res.data.parameters.defaultParam).to.equal('abcdefg')
-        expect(res.data.parameters['X-start']).to.equal(22)
     })
 
     it('passes query parameters in POST', async function () {
         const res = await util.axios.request({
             url: 'api/parameters',
             method: 'post',
-            params: {
-                'num': 165.75,
-                'int': 776,
-                'bool': true,
-                'string': '&a=22'
-            },
+            params,
             headers: {
                 "X-start": 22
             }
         })
+
         expect(res.status).to.equal(200)
         expect(res.data.method).to.equal('post')
         expect(res.data.parameters.num).to.be.a('number')
-        expect(res.data.parameters.num).to.equal(165.75)
+        expect(res.data.parameters.num).to.equal(params.num)
         expect(res.data.parameters.bool).to.be.a('boolean')
-        expect(res.data.parameters.bool).to.be.true
+        expect(res.data.parameters.bool).to.equal(params.bool)
         expect(res.data.parameters.int).to.be.a('number')
-        expect(res.data.parameters.int).to.equal(776)
-        expect(res.data.parameters.string).to.equal('&a=22')
+        expect(res.data.parameters.int).to.equal(params.int)
+        expect(res.data.parameters.string).to.equal(params.string)
+
+        expect(res.data.parameters['X-start']).to.equal(headers['X-start'])
+
         expect(res.data.parameters.defaultParam).to.equal('abcdefg')
-        expect(res.data.parameters['X-start']).to.equal(22)
     })
 
     it('handles date parameters', async function () {


### PR DESCRIPTION
fix(parameters): decode path parameters

refs #25

Percent encoded special characters in path parameter are decoded.

With a route `api/{file}` the request URL `api/test%20one` the value of `$request?parameters?file`  will be "test one".