### PR TITLE
fix: add fallback description to router:error-description

### DIFF
--- a/content/router.xql
+++ b/content/router.xql
@@ -386,7 +386,7 @@ declare %private function router:error-description ($description as xs:string?, 
     if ($line and $line > 0 and empty($value)) then
         ``[`{$description}` [at line `{$line}` column `{$column}` in module `{head(($module, 'unknown'))}`]]``
     else
-        ($description, $value)[1]
+        ($description, $value, 'No description provided.')[1]
 };
 
 (:~


### PR DESCRIPTION
fixes #73 
If the error raised does neither have a description nor a value it will now return "No description provided."