### PR TITLE
Improve login and cookie handling

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,10 +30,10 @@ jobs:
           --health-interval 4s
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - name: Install dependencies
         run: npm ci
       - name: Run tests
@@ -48,10 +48,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Use Node.js 16
+      - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - name: Install dependencies
         run: npm ci
       - name: Release

--- a/content/auth.xql
+++ b/content/auth.xql
@@ -25,7 +25,7 @@ import module namespace session = "http://exist-db.org/xquery/session";
 import module namespace router="http://e-editiones.org/roaster/router";
 import module namespace rutil="http://e-editiones.org/roaster/util";
 import module namespace errors="http://e-editiones.org/roaster/errors";
-import module namespace cookie="http://e-editiones.org/roaster/cookie" at "cookie.xqm";
+import module namespace cookie="http://e-editiones.org/roaster/cookie";
 
 (: API Request Authentication and Authorisation :)
 

--- a/content/cookie.xqm
+++ b/content/cookie.xqm
@@ -1,0 +1,93 @@
+(:
+ :  Copyright (C) 2024 TEI Publisher Project Team
+ :
+ :  This program is free software: you can redistribute it and/or modify
+ :  it under the terms of the GNU General Public License as published by
+ :  the Free Software Foundation, either version 3 of the License, or
+ :  (at your option) any later version.
+ :
+ :  This program is distributed in the hope that it will be useful,
+ :  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ :  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ :  GNU General Public License for more details.
+ :
+ :  You should have received a copy of the GNU General Public License
+ :  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ :)
+module namespace cookie="http://e-editiones.org/roaster/cookie";
+
+import module namespace response="http://exist-db.org/xquery/response";
+import module namespace errors="http://e-editiones.org/roaster/errors";
+
+declare %private variable $cookie:enforce-rfc2109 := "[/()<>@,;:\\""\[\]\?=\{\} \t]";
+
+(:~
+ : Custom implementation of response:set-cookie in XQuery
+ : Uses response:set-header instead
+ : The cookie is built from the passed in map
+ : This allows to set more cookie attributes
+ : Specifically, SameSite and HttpOnly
+ :
+ : name and value are mandatory, 
+ : if they are missing an error is raised with code $errors:OPERATION.
+ : The same error will be raised, if maxAge is not an
+ : instance of xs:dayTimeDuration
+ :
+ : Example Input
+   map {
+    "name": "awesome.cookie",
+    "value": "._.*^*._.*^*._.*^*._.*^*._.*",
+    "maxAge": xs:dayTimeDuration("P1D"),
+    "Path": "/",
+    "SameSite": "Strict",
+    "Secure": false(),
+    "HttpOnly": true()
+    }
+ :)
+declare function cookie:set($options as map(*)) as empty-sequence() {
+    response:set-header('Set-Cookie', string-join(
+        (
+            cookie:name-and-value($options),
+            cookie:lifetime($options),
+            cookie:add-property($options, "Domain"),
+            cookie:add-property($options, "Path"),
+            cookie:add-property($options, "SameSite"),
+            cookie:add-flag($options, "Secure"),
+            cookie:add-flag($options, "HttpOnly")
+        ),
+        "; "
+    ))
+};
+
+declare %private function cookie:name-and-value($options as map(*)) as xs:string {
+    if (empty($options?("name")) or empty($options?("value"))) then (
+        error($errors:OPERATION, "Cookie name and value must be set", $options)
+    ) else if (matches($options?name, $cookie:enforce-rfc2109)) then (
+        error($errors:OPERATION, "Cookie name contains illegal charecters", $options)
+    ) else if ($options?name = ("Domain", "Path", "SameSite", "Secure", "HttpOnly")) then (
+        error($errors:OPERATION, "Cookie name cannot be equal to property name", $options)
+    ) else (
+        $options?name || "=" || $options?value
+    )
+};
+
+declare %private function cookie:lifetime($options as map(*)) as xs:string* {
+    if (empty($options?maxAge)) then ()
+    else if (not($options?maxAge instance of xs:dayTimeDuration)) then (
+        error($errors:OPERATION, "maxAge must be an instance of xs:dayTimeDuration", $options)
+    ) else (
+        "Max-Age=" || ($options?maxAge div xs:dayTimeDuration('PT1S')),
+        "Expires=" || string(current-dateTime() + $options?maxAge)
+    )
+};
+
+declare %private function cookie:add-property($options as map(*), $property as xs:string) as xs:string? {
+    if (empty($options?($property))) then () else (
+        $property || "=" || $options?($property)
+    )
+};
+
+declare %private function cookie:add-flag($options as map(*), $property as xs:string) as xs:string? {
+    if (boolean($options?($property))) then ($property) else ()
+};
+

--- a/content/router.xql
+++ b/content/router.xql
@@ -281,7 +281,12 @@ declare %private function router:execute-handler ($base-request as map(*), $use,
             let $response := $request-response-array?2
 
             let $fn := $lookup($base-request?config?operationId)
-            let $handler-response := $fn($request)
+            let $handler-response :=
+                if (empty($fn)) then (
+                    error($errors:OPERATION, 'Operation not found for operationId:"' || $base-request?config?operationId || '"', $base-request?config)
+                ) else (
+                    $fn($request)
+                )
 
             return
                 if (router:is-response-map($handler-response)) then

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -30,4 +30,8 @@
         <namespace>http://e-editiones.org/roaster/body</namespace>
         <file>body.xqm</file>
     </xquery>
+    <xquery>
+        <namespace>http://e-editiones.org/roaster/cookie</namespace>
+        <file>cookie.xqm</file>
+    </xquery>
 </package>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^8.0.6",
-        "axios": "^1.1.3",
+        "axios": "^1.7.5",
         "chai": "^4.3.7",
         "chai-openapi-response-validator": "^0.14.2",
         "chokidar": "^3.5.3",
@@ -1084,11 +1084,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.1.3",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
+      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -3041,7 +3042,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {
@@ -3049,7 +3052,6 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^8.0.6",
-    "axios": "^1.1.3",
+    "axios": "^1.7.5",
     "chai": "^4.3.7",
     "chai-openapi-response-validator": "^0.14.2",
     "chokidar": "^3.5.3",

--- a/test/app/api.json
+++ b/test/app/api.json
@@ -68,17 +68,7 @@
                 "summary": "User Logout",
                 "description": "End session of the current user",
                 "operationId": "auth:logout",
-                "tags": ["auth", "query"],
-                "parameters": [
-                    {
-                        "name": "logout",
-                        "in": "query",
-                        "description": "Set to some value to log out the current user",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
+                "tags": ["auth"],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -87,18 +77,9 @@
                                 "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "success": { "type": "boolean" }
+                                        "success": { "type": "boolean" },
+                                        "message": { "type": "string" }
                                     }
-                                }
-                            }
-                        }
-                    },
-                    "301": {
-                        "description": "Redirect with the logout parameter set.",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "type": "string"
                                 }
                             }
                         }
@@ -107,15 +88,171 @@
                 }
             }
         },
+        "/api/logout": {
+            "get": {
+                "summary": "User Logout",
+                "description": "End session of the current user",
+                "operationId": "api:logout",
+                "tags": ["auth"],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": { "type": "string" }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": { "description": "unauthorized" }
+                }
+            }
+        },
+        "/api/login": {
+            "post": {
+                "summary": "Custom user Login",
+                "description": "Custom login handler using different properties",
+                "tags": ["auth", "body"],
+                "operationId": "api:login",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [ "usr" ],
+                                "properties": {
+                                    "usr": {
+                                        "description": "Username",
+                                        "type": "string"
+                                    },
+                                    "pwd": {
+                                        "description": "Password",
+                                        "type": "string",
+                                        "format": "password"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": { "type": "string" }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Wrong user or password",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": { "type": "string" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": []
+            }
+        },
+        "/api/login-xml": {
+            "post": {
+                "summary": "Login with XML",
+                "description": "Custom login handler using XML body",
+                "tags": ["auth", "body"],
+                "operationId": "api:login-xml",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/xml": {
+                            "schema": {
+                                "type": "object",
+                                "required": [ "username" ],
+                                "properties": {
+                                    "username": {
+                                        "description": "Username",
+                                        "type": "string"
+                                    },
+                                    "password": {
+                                        "description": "Password",
+                                        "type": "string",
+                                        "format": "password"
+                                    }
+                                },
+                                "xml": {
+                                    "wrapped": true,
+                                    "name": "login"
+                                }
+                            }
+                    }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Wrong user or password",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": []
+            }
+        },
         "/login": {
             "post": {
                 "summary": "User Login",
-                "description": "Start an authenticated session for the given user",
+                "description": "Start an authenticated session using roaster's login route handler",
                 "tags": ["auth", "body"],
                 "operationId": "auth:login",
                 "requestBody": {
                     "required": true,
                     "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [ "user" ],
+                                "properties": {
+                                    "user": {
+                                        "description": "Name of the user",
+                                        "type": "string"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "format": "password"
+                                    }
+                                }
+                            }
+                        },
                         "multipart/form-data": {
                             "schema": {
                                 "type": "object",

--- a/test/app/modules/api.xql
+++ b/test/app/modules/api.xql
@@ -112,6 +112,65 @@ declare function api:avatar ($request as map(*)) {
     </svg>
 };
 
+(:~
+ : override default authentication options
+ :)
+declare variable $api:auth-options := map {
+    "asDba": false(),
+    "createSession": false(),
+    "maxAge": xs:dayTimeDuration("PT10S"), (: set the cookie time-out to 10 seconds :)
+    "Path": "/exist/apps/roasted", (: requests must include this path for the cookie to be included :)
+    "SameSite": "Lax", (: sets the SameSite property to either "None", "Strict" or "Lax"  :)
+    "Secure": true(), (: mark the cookie as secure :)
+    "HttpOnly": true() (: sets the HttpOnly property :)
+};
+
+(:~
+ : Example login route handler using non-standard propertys
+ : within the request body to authenticate users against exist-db.
+ : The data can also be supplied as JSON
+ :)
+declare function api:login ($request as map(*)) {
+    let $user := auth:login-user(
+        $request?body?usr, $request?body?pwd, 
+        auth:add-login-domain($request, $api:auth-options))
+
+    return if (empty($user)) then (
+        roaster:response(401, "application/json",
+            map{ "message": "Wrong user or password" })
+    ) else (
+        (: the request can also be redirected here :)
+        map{ "message": concat("Logged in as ", $user) }
+    )
+};
+
+(:~
+ : Example login route handler using XML
+ :)
+declare function api:login-xml ($request as map(*)) {
+    let $user := auth:login-user(
+        $request?body//user/string(), $request?body//password/string(), 
+        auth:add-login-domain($request, $api:auth-options))
+
+    return if (empty($user)) then (
+        roaster:response(401, "application/xml",
+            <message>Wrong user or password</message>)
+    ) else (
+        (: the request can also be redirected here :)
+        roaster:response(200, "application/xml",
+            <message>Logged in as {$user}</message>)
+    )
+};
+
+(:~
+ : Example logout route handler
+ :)
+declare function api:logout ($request as map(*)) {
+    auth:logout-user(auth:add-login-domain($request, $api:auth-options)),
+    (: the request can also be redirected here :)
+    map{ "message": "Logged out" }
+};
+
 (: end of route handlers :)
 
 (:~

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -2,40 +2,507 @@ const util = require('./util.js')
 const chai = require('chai')
 const expect = chai.expect
 
+function parseCookies(cookies) {
+    return cookies.map(parseCookieString)
+}
+
+function parseCookieString (cookieString) {
+    return cookieString.split(';')
+            .map(kv => kv.split('='))
+            .reduce((acc, next) => {
+                const key = decodeURIComponent(next[0].trim())
+                const value = next[1] ? decodeURIComponent(next[1].trim()) : true
+                acc[key] = value;
+                return acc;
+            }, {})
+}
+
+function oneCookieHas(key) {
+    return cookies => cookies.filter(cookie => (key in cookie)).length === 1
+}
+
+function getCookieWith(cookies, key) {
+    return cookies.filter(cookie => (key in cookie))[0]
+}
+
+const testAppLoginDomain = 'roasted.com.login'
+const jettySessionId = 'JSESSIONID'
+
 describe('On Login', function () {
-    let response
+    describe('using multipart/form-data', function(){
+    let cookie, parsedCookies
 
     before(async function () {
-        await util.login()
-        response = await util.axios.get('api/parameters', {})
+        let res = await util.axios.post('login', util.authForm, {
+            headers: { 'Content-Type': 'multipart/form-data' }
+        })
+        cookie = res.headers['set-cookie'];
+        parsedCookies = parseCookies(cookie)
     })
 
-    it('public route can be called', function () {
-        expect(response.status).to.equal(200);
+    it('sets two cookies', function () {
+        expect(cookie).to.have.lengthOf(2)
     })
 
-    it('user property is set on request map', function () {
-        expect(response.data.user).to.be.a('object')
-        expect(response.data.user.name).to.equal("admin")
-        expect(response.data.user.dba).to.equal(true)
+    it('sets the ' + jettySessionId + ' cookie', function () {
+        expect(parsedCookies).to.satisfy(oneCookieHas(jettySessionId))
+    })
+
+    it('sets the login domain cookie', function () {
+        expect(parsedCookies).to.satisfy(oneCookieHas(testAppLoginDomain))
+    })
+
+    it('domain cookie has defaults', function () {
+        const domainCookie = getCookieWith(parsedCookies, testAppLoginDomain)
+        expect(domainCookie).to.exist
+        expect(domainCookie).to.have.property('Path')
+        expect(domainCookie['Path']).to.equal('/exist')
+        expect(domainCookie).to.have.property('Max-Age')
+        expect(domainCookie['Max-Age']).to.equal('604800')
+        expect(domainCookie).to.have.property('Expires')
+        expect(new Date(domainCookie.Expires).getTime()).to.be.greaterThan(Date.now())
+    })
+
+    describe('using cookie auth', function () {
+        let publicRouteResponse
+
+        before(async function () {
+            publicRouteResponse = await util.axios.get('api/parameters', { headers: { cookie } })
+        })
+
+        it('public route can be called', async function () {
+            expect(publicRouteResponse.status).to.equal(200);
+        })
+
+        it('sets the correct user', function () {
+            expect(publicRouteResponse.data.user).to.be.a('object')
+            expect(publicRouteResponse.data.user.name).to.equal("admin")
+            expect(publicRouteResponse.data.user.dba).to.equal(true)
+        })
     })
 
     describe('On logout', function () {
-        let logoutResponse
-        let guestResponse
+        let logoutResponse, guestResponse, updatedCookie, parsedCookies
+
         before(async function () {
-            logoutResponse = await util.axios.get('logout')
-            guestResponse = await util.axios.get('api/parameters', {})
+            logoutResponse = await util.axios.get('logout', { headers: { cookie }})
+            console.log(logoutResponse)
+            updatedCookie = logoutResponse.headers['set-cookie'];
+            parsedCookies = parseCookies(updatedCookie)
+            guestResponse = await util.axios.get('api/parameters', { headers: { cookie: updatedCookie }})
         })
+
         it('request returns true', function () {
             expect(logoutResponse.status).to.equal(200)
             expect(logoutResponse.data.success).to.equal(true)
         })
-        it('public route sets guest as user', function () {
+
+        it('invalidates session and domain cookie', function () {
+            expect(updatedCookie.length).to.equal(1)
+            // expect(parsedCookies).to.satisfy(oneCookieHas(jettySessionId))
+            expect(parsedCookies).to.satisfy(oneCookieHas(testAppLoginDomain))
+            const domainCookie = getCookieWith(parsedCookies, testAppLoginDomain)
+            expect(domainCookie[testAppLoginDomain]).to.equal('deleted')
+        })
+
+        it('public route sets guest as user', async function () {
             expect(guestResponse.status).to.equal(200)
             expect(guestResponse.data.user.name).to.equal("guest")
             expect(guestResponse.data.user.dba).to.equal(false)
         })
 
+        it('invalidated cookie reverts to guest access', async function () {
+            const responseWithOldCookies = await util.axios.get('api/parameters', { headers: { cookie }})
+            expect(responseWithOldCookies.status).to.equal(200)
+            expect(responseWithOldCookies.data.user.name).to.equal("guest")
+            expect(responseWithOldCookies.data.user.dba).to.equal(false)
+        })
+    })
+    })
+
+    describe('using application/x-www-form-urlencoded', function(){
+        let cookie, parsedCookies
+
+        before(async function () {
+            const urlEncodedAuthForm = new URLSearchParams(util.authForm).toString()
+            const res = await util.axios.post('login', urlEncodedAuthForm, {
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+            })
+            cookie = res.headers['set-cookie'];
+            parsedCookies = parseCookies(cookie)
+        })
+
+        it('sets two cookies', function () {
+            expect(cookie).to.have.lengthOf(2)
+        })
+
+        it('sets the ' + jettySessionId + ' cookie', function () {
+            expect(parsedCookies).to.satisfy(oneCookieHas(jettySessionId))
+        })
+
+        it('sets the login domain cookie', function () {
+            expect(parsedCookies).to.satisfy(oneCookieHas(testAppLoginDomain))
+        })
+
+        it('sets a cookie with defaults', function () {
+            const domainCookie = getCookieWith(parsedCookies, testAppLoginDomain)
+            expect(domainCookie).to.exist
+            expect(domainCookie).to.have.property('Path')
+            expect(domainCookie['Path']).to.equal('/exist')
+            expect(domainCookie).to.have.property('Max-Age')
+            expect(domainCookie['Max-Age']).to.equal('604800')
+            expect(domainCookie).to.have.property('Expires')
+            expect(new Date(domainCookie.Expires).getTime()).to.be.greaterThan(Date.now())
+        })
+
+        describe('sets the correct user using cookie auth', function () {
+            let publicRouteResponse
+
+            before(async function () {
+                publicRouteResponse = await util.axios.get('api/parameters', { headers: { cookie } })
+            })
+
+            it('public route can be called', async function () {
+                expect(publicRouteResponse.status).to.equal(200);
+            })
+
+            it('user property is set on request map', function () {
+                expect(publicRouteResponse.data.user).to.be.a('object')
+                expect(publicRouteResponse.data.user.name).to.equal("admin")
+                expect(publicRouteResponse.data.user.dba).to.equal(true)
+            })
+        })
+
+        describe('On logout', function () {
+            let logoutResponse, guestResponse
+
+            before(async function () {
+                logoutResponse = await util.axios.get('logout', { headers: { cookie }})
+                updatedCookie = logoutResponse.headers['set-cookie'];
+                guestResponse = await util.axios.get('api/parameters', { headers: { updatedCookie }})
+            })
+            it('request returns true', function () {
+                expect(logoutResponse.status).to.equal(200)
+                expect(logoutResponse.data.success).to.equal(true)
+            })
+            it('public route sets guest as user', async function () {
+                expect(guestResponse.status).to.equal(200)
+                expect(guestResponse.data.user.name).to.equal("guest")
+                expect(guestResponse.data.user.dba).to.equal(false)
+            })
+        })
+    })
+    describe('using application/json', function(){
+        let cookie, parsedCookies
+    
+        before(async function () {
+            const data = {
+                user: util.adminCredentials.username,
+                password: util.adminCredentials.password
+            }
+            
+            const res = await util.axios.post('login', data, {
+                headers: { 'Content-Type': 'application/json' }
+            })
+            cookie = res.headers['set-cookie'];
+            parsedCookies = parseCookies(cookie)
+        })
+    
+        it('sets two cookies', function () {
+            expect(cookie).to.have.lengthOf(2)
+        })
+    
+        it('sets the ' + jettySessionId + ' cookie', function () {
+            expect(parsedCookies).to.satisfy(oneCookieHas(jettySessionId))
+        })
+    
+        it('sets the login domain cookie', function () {
+            expect(parsedCookies).to.satisfy(oneCookieHas(testAppLoginDomain))
+        })
+    
+        it('domain cookie has defaults', function () {
+            const domainCookie = getCookieWith(parsedCookies, testAppLoginDomain)
+            expect(domainCookie).to.exist
+            expect(domainCookie).to.have.property('Path')
+            expect(domainCookie['Path']).to.equal('/exist')
+            expect(domainCookie).to.have.property('Max-Age')
+            expect(domainCookie['Max-Age']).to.equal('604800')
+            expect(domainCookie).to.have.property('Expires')
+            expect(new Date(domainCookie.Expires).getTime()).to.be.greaterThan(Date.now())
+        })
+    
+        describe('sets the correct user using cookie auth', function () {
+            let publicRouteResponse
+    
+            before(async function () {
+                publicRouteResponse = await util.axios.get('api/parameters', { headers: { cookie } })
+            })
+    
+            it('public route can be called', async function () {
+                expect(publicRouteResponse.status).to.equal(200);
+            })
+    
+            it('user property is set on request map', function () {
+                expect(publicRouteResponse.data.user).to.be.a('object')
+                expect(publicRouteResponse.data.user.name).to.equal("admin")
+                expect(publicRouteResponse.data.user.dba).to.equal(true)
+            })
+        })
+    
+        describe('On logout', function () {
+            let logoutResponse, guestResponse, updatedCookie, parsedCookies
+    
+            before(async function () {
+                logoutResponse = await util.axios.get('logout', { headers: { cookie }})
+                updatedCookie = logoutResponse.headers['set-cookie'];
+                parsedCookies = parseCookies(updatedCookie)
+                guestResponse = await util.axios.get('api/parameters', { headers: { cookie: updatedCookie }})
+            })
+    
+            it('request returns true', function () {
+                expect(logoutResponse.status).to.equal(200)
+                expect(logoutResponse.data.success).to.equal(true)
+            })
+    
+            it('invalidates session and domain cookie', function () {
+                expect(updatedCookie.length).to.equal(1)
+                // expect(parsedCookies).to.satisfy(oneCookieHas(jettySessionId))
+                expect(parsedCookies).to.satisfy(oneCookieHas(testAppLoginDomain))
+                const domainCookie = getCookieWith(parsedCookies, testAppLoginDomain)
+                expect(domainCookie[testAppLoginDomain]).to.equal('deleted')
+            })
+    
+            it('public route sets guest as user', async function () {
+                expect(guestResponse.status).to.equal(200)
+                expect(guestResponse.data.user.name).to.equal("guest")
+                expect(guestResponse.data.user.dba).to.equal(false)
+            })
+    
+            it('invalidated cookie reverts to guest access', async function () {
+                const responseWithOldCookies = await util.axios.get('api/parameters', { headers: { cookie }})
+                expect(responseWithOldCookies.status).to.equal(200)
+                expect(responseWithOldCookies.data.user.name).to.equal("guest")
+                expect(responseWithOldCookies.data.user.dba).to.equal(false)
+            })
+        })
+    })
+
+    describe('custom login using application/json', function(){
+        let cookie, parsedCookies, domainCookie
+    
+        before(async function () {
+            const data = {
+                usr: util.adminCredentials.username,
+                pwd: util.adminCredentials.password
+            }
+            
+            const res = await util.axios.post('api/login', data, {
+                headers: { 'Content-Type': 'application/json' }
+            })
+            cookie = res.headers['set-cookie'];
+            parsedCookies = parseCookies(cookie)
+            domainCookie = getCookieWith(parsedCookies, testAppLoginDomain)
+        })
+    
+        it('sets two cookies', function () {
+            expect(cookie).to.have.lengthOf(1)
+        })
+    
+        it('does not set the ' + jettySessionId + ' cookie', function () {
+            expect(parsedCookies).to.not.satisfy(oneCookieHas(jettySessionId))
+        })
+    
+        it('sets the login domain cookie', function () {
+            expect(domainCookie).to.exist
+        })
+    
+        it('domain cookie has defaults', function () {
+            expect(domainCookie).to.have.property('Path')
+            expect(domainCookie['Path']).to.equal('/exist/apps/roasted')
+            expect(domainCookie).to.have.property('Expires')
+            expect(new Date(domainCookie.Expires).getTime()).to.be.greaterThan(Date.now())
+        })
+
+        it('domain cookie has short lifetime', function () {
+            expect(domainCookie).to.have.property('Max-Age')
+            expect(domainCookie['Max-Age']).to.equal('10')
+        })
+
+        it('domain cookie has SameSite=strict', function () {
+            expect(domainCookie).to.have.property('SameSite')
+            expect(domainCookie['SameSite']).to.equal('Lax')
+        })
+
+        it('domain cookie has Secure', function () {
+            expect(domainCookie).to.have.property('Secure')
+        })
+
+        it('domain cookie has HttpOnly', function () {
+            expect(domainCookie).to.have.property('HttpOnly')
+        })
+
+        describe('sets the correct user using cookie auth', function () {
+            let publicRouteResponse
+    
+            before(async function () {
+                publicRouteResponse = await util.axios.get('api/parameters', { headers: { cookie } })
+            })
+    
+            it('public route can be called', async function () {
+                expect(publicRouteResponse.status).to.equal(200);
+            })
+    
+            it('user property is set on request map', function () {
+                expect(publicRouteResponse.data.user).to.be.a('object')
+                expect(publicRouteResponse.data.user.name).to.equal("admin")
+                expect(publicRouteResponse.data.user.dba).to.equal(true)
+            })
+        })
+    
+        describe('On logout', function () {
+            let logoutResponse, guestResponse, updatedCookie, parsedCookies
+    
+            before(async function () {
+                logoutResponse = await util.axios.get('api/logout', { headers: { cookie }})
+                updatedCookie = logoutResponse.headers['set-cookie'];
+                parsedCookies = parseCookies(updatedCookie)
+                guestResponse = await util.axios.get('api/parameters', { headers: { cookie: updatedCookie }})
+            })
+    
+            it('request returns a message', function () {
+                expect(logoutResponse.status).to.equal(200)
+                expect(logoutResponse.data.message).to.exist
+            })
+    
+            it('invalidates domain cookie', function () {
+                expect(updatedCookie.length).to.equal(1)
+                domainCookie = getCookieWith(parsedCookies, testAppLoginDomain)
+                expect(domainCookie).to.exist
+                expect(domainCookie[testAppLoginDomain]).to.equal('deleted')
+            })
+    
+            it('public route sets guest as user', async function () {
+                expect(guestResponse.status).to.equal(200)
+                expect(guestResponse.data.user.name).to.equal("guest")
+                expect(guestResponse.data.user.dba).to.equal(false)
+            })
+    
+            it('invalidated cookie reverts to guest access', async function () {
+                const responseWithOldCookies = await util.axios.get('api/parameters', { headers: { cookie }})
+                expect(responseWithOldCookies.status).to.equal(200)
+                expect(responseWithOldCookies.data.user.name).to.equal("guest")
+                expect(responseWithOldCookies.data.user.dba).to.equal(false)
+            })
+        })
+    })
+
+    describe('custom XML login using application/xml', function(){
+        let cookie, parsedCookies, domainCookie
+    
+        before(async function () {
+            const data = `
+<login>
+  <user>${util.adminCredentials.username}</user>
+  <password>${util.adminCredentials.password}</password>
+</login>
+`
+            const res = await util.axios.post('api/login-xml', data, {
+                headers: { 'Content-Type': 'application/xml' }
+            })
+            cookie = res.headers['set-cookie'];
+            parsedCookies = parseCookies(cookie)
+            domainCookie = getCookieWith(parsedCookies, testAppLoginDomain)
+        })
+    
+        it('sets one cookie', function () {
+            expect(cookie).to.have.lengthOf(1)
+        })
+    
+        it('does not set the ' + jettySessionId + ' cookie', function () {
+            expect(parsedCookies).to.not.satisfy(oneCookieHas(jettySessionId))
+        })
+    
+        it('sets the login domain cookie', function () {
+            expect(domainCookie).to.exist
+        })
+    
+        it('domain cookie has defaults', function () {
+            expect(domainCookie).to.have.property('Path')
+            expect(domainCookie['Path']).to.equal('/exist/apps/roasted')
+            expect(domainCookie).to.have.property('Expires')
+            expect(new Date(domainCookie.Expires).getTime()).to.be.greaterThan(Date.now())
+        })
+
+        it('domain cookie has short lifetime', function () {
+            expect(domainCookie).to.have.property('Max-Age')
+            expect(domainCookie['Max-Age']).to.equal('10')
+        })
+
+        it('domain cookie has SameSite=strict', function () {
+            expect(domainCookie).to.have.property('SameSite')
+            expect(domainCookie['SameSite']).to.equal('Lax')
+        })
+
+        it('domain cookie has Secure', function () {
+            expect(domainCookie).to.have.property('Secure')
+        })
+
+        it('domain cookie has HttpOnly', function () {
+            expect(domainCookie).to.have.property('HttpOnly')
+        })
+
+        describe('sets the correct user using cookie auth', function () {
+            let publicRouteResponse
+
+            before(async function () {
+                publicRouteResponse = await util.axios.get('api/parameters', { headers: { cookie } })
+            })
+
+            it('public route can be called', async function () {
+                expect(publicRouteResponse.status).to.equal(200);
+            })
+
+            it('user property is set on request map', function () {
+                expect(publicRouteResponse.data.user).to.be.a('object')
+                expect(publicRouteResponse.data.user.name).to.equal("admin")
+                expect(publicRouteResponse.data.user.dba).to.equal(true)
+            })
+        })
+
+        describe('On logout', function () {
+            let logoutResponse, guestResponse, updatedCookie, parsedCookies
+
+            before(async function () {
+                logoutResponse = await util.axios.get('api/logout', { headers: { cookie }})
+                updatedCookie = logoutResponse.headers['set-cookie'];
+                parsedCookies = parseCookies(updatedCookie)
+                guestResponse = await util.axios.get('api/parameters', { headers: { cookie: updatedCookie }})
+            })
+
+            it('request returns a message', function () {
+                expect(logoutResponse.status).to.equal(200)
+                expect(logoutResponse.data.message).to.exist
+            })
+
+            it('invalidates session and domain cookie', function () {
+                expect(updatedCookie.length).to.equal(1)
+                expect(parsedCookies).to.satisfy(oneCookieHas(testAppLoginDomain))
+                const domainCookie = getCookieWith(parsedCookies, testAppLoginDomain)
+                expect(domainCookie[testAppLoginDomain]).to.equal('deleted')
+            })
+
+            it('public route sets guest as user', async function () {
+                expect(guestResponse.status).to.equal(200)
+                expect(guestResponse.data.user.name).to.equal("guest")
+                expect(guestResponse.data.user.dba).to.equal(false)
+            })
+
+            it('invalidated cookie reverts to guest access', async function () {
+                const responseWithOldCookies = await util.axios.get('api/parameters', { headers: { cookie }})
+                expect(responseWithOldCookies.status).to.equal(200)
+                expect(responseWithOldCookies.data.user.name).to.equal("guest")
+                expect(responseWithOldCookies.data.user.dba).to.equal(false)
+            })
+        })
     })
 })

--- a/test/mediatype.test.js
+++ b/test/mediatype.test.js
@@ -45,6 +45,7 @@ describe("Binary up and download", function () {
             expect(res.status).to.equal(201)
             expect(res.data).to.equal(dbUploadCollection + filename)
         })
+
         it('retrieves the data', async function () {
             const res = await util.axios.get(downloadApiEndpoint + filename, { responseType: 'arraybuffer' })
             expect(res.status).to.equal(200)
@@ -422,7 +423,7 @@ test.
             return util.axios.post(
                 'upload/single/' + filename,
                 data,
-                { headers }                
+                { headers }
             )
             .then(r => uploadResponse = r)
             .catch(e => uploadResponse = e.response )

--- a/test/paths.test.js
+++ b/test/paths.test.js
@@ -78,44 +78,6 @@ describe('Prefixed known path', function () {
     });
 });
 
-describe("Binary up and download", function () {
-    const contents = fs.readFileSync("./dist/roasted.xar")
-
-    before(async function () {
-        await util.login()
-        response = await util.axios.get('api/parameters', {})
-    })
-
-    it('public route can be called', function () {
-        expect(response.status).to.equal(200);
-    })
-
-    it('user property is set on request map', function () {
-        expect(response.data.user).to.be.a('object')
-        expect(response.data.user.name).to.equal("admin")
-        expect(response.data.user.dba).to.equal(true)
-    })
-
-    describe('On logout', function () {
-        let logoutResponse
-        let guestResponse
-        before(async function () {
-            logoutResponse = await util.axios.get('logout')
-            guestResponse = await util.axios.get('api/parameters', {})
-        })
-        it('request returns true', function () {
-            expect(logoutResponse.status).to.equal(200)
-            expect(logoutResponse.data.success).to.equal(true)
-        })
-        it('public route sets guest as user', function () {
-            expect(guestResponse.status).to.equal(200)
-            expect(guestResponse.data.user.name).to.equal("guest")
-            expect(guestResponse.data.user.dba).to.equal(false)
-        })
-
-    })
-})
-
 describe('Request body', function() {
     it('uploads string in body', async function() {
         const res = await util.axios.post('api/$op-er+ation*!');


### PR DESCRIPTION
**FEATURES**

- allow and encourage custom login route handlers
  - read user name and login from any body or header content __including XML bodies__
- allow and encourage custom logout route handlers
- allows setting `HttpOnly` and `SameSite` attributes on login domain cookies (implementation in `content/cookie.xqm`)

**FIXES**

- no redirect needed for logout, nor `logout=true`
- do not attempt to login on __every request__
- get rid of hard-coded field names `user`, `password`
