### PR TITLE
feat(put multipart): add parsing for multipart content with methods other than POST

### DIFF
--- a/content/body.xqm
+++ b/content/body.xqm
@@ -277,7 +277,11 @@ declare function body:parse-multipart ( $data as xs:string, $header as xs:string
             else $val
           return map:entry(substring-before($line, ': '), $value)
       )
-      let $body := string-join($parts[position() > 1], '\n')
+      (: eXist’s parse-xml does not like XML declarations… :)
+      let $bodyJoined := string-join($parts[position() > 1], '\n')
+        , $body := if ( matches($bodyJoined, '^\s+<\?xml version="1.0" encoding="UTF-8"\?>') )
+                then substring-after($bodyJoined, '?>')
+                else $bodyJoined
       
       (: empty lines in the body will also cause splitting; hence, recombine everything except the header :)
       return map:entry(($header?Content-Disposition?name, 'name')[1],


### PR DESCRIPTION
As described in #104, eXist does not currently parse multipart content for anything but POST requests.
When PUTing multipart content, roaster will fail as it cannot find the required parameters.

This PR adds parsing of multipart content for other request types, creating a structure basically identical to that of eXist’s native parsing.