### PR TITLE
fix: look up OpenAPI response definition by string status code

### DIFF
--- a/content/router.xql
+++ b/content/router.xql
@@ -329,7 +329,10 @@ declare %private function router:execute-handler ($base-request as map(*), $use,
 (: content types :)
 
 declare function router:get-content-type-for-code ($config as map(*), $code as xs:integer, $fallback as xs:string) as xs:string {
-    let $response-definition := head(($config?responses?($code), $config?responses?default))
+    (: OpenAPI response keys are strings ("200", "default"); look up the integer status code by its
+     : string form. (Indexing the string-keyed responses map with the integer $code only ever matched
+     : because of eXist's pre-conformance map-key coercion, removed in eXist-db/exist#6491.) :)
+    let $response-definition := head(($config?responses?(string($code)), $config?responses?default))
     let $content := 
         if (exists($response-definition) and $response-definition instance of map(*))
         then $response-definition?content

--- a/test/responsetype.test.js
+++ b/test/responsetype.test.js
@@ -1,0 +1,38 @@
+const util = require('./util.js')
+const chai = require('chai')
+const expect = chai.expect
+
+// Regression test for eXist-db/exist#6491 (map keys compare by op:same-key, no cross-family coercion).
+//
+// router:get-content-type-for-code looks up the OpenAPI responses map - whose keys are strings
+// ("200", "default") because it is parsed from the OpenAPI definition - by the integer status $code.
+// Before #6491, eXist coerced the integer lookup key to the map's string key type, so 200 matched
+// "200"; after #6491 it does not, so the lookup must use string($code). If this regresses, the
+// response definition comes back empty, the content type falls back to application/xml, output:method
+// is set to "xml", and a JSON response body (a map) is serialized as XML - surfacing as SENR0001.
+//
+// api:arrays-get returns a bare map { "parameters": ... } with no explicit response type, so the
+// content type is negotiated solely from the numeric status code via get-content-type-for-code -
+// exactly the path the bug breaks.
+describe('response content type negotiated from the numeric status code (#6491 regression)', function () {
+    let res
+    before(async function () {
+        res = await util.axios.get('api/arrays', {
+            params: { piped: 'one|two' },
+            paramsSerializer: { indexes: null }
+        })
+    })
+
+    it('responds 200', function () {
+        expect(res.status).to.equal(200)
+    })
+
+    it('negotiates application/json from the "200" response (not the application/xml fallback)', function () {
+        expect(res.headers['content-type']).to.match(/application\/json/)
+    })
+
+    it('returns a parsed JSON object, not a map serialized as XML', function () {
+        expect(res.data).to.be.an('object')
+        expect(res.data.parameters).to.be.an('object')
+    })
+})


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

`router:get-content-type-for-code` indexes the OpenAPI `responses` map with the integer status `$code`:

```xquery
let $response-definition := head(($config?responses?($code), $config?responses?default))
```

`$config?responses` is parsed from the OpenAPI definition, so its keys are **strings** (`"200"`, `"404"`, `"default"`), while `$code` is an `xs:integer`. Indexing a string-keyed map with an integer key only ever matched because of eXist's pre-conformance map-key *coercion* (the integer lookup key was cast to the map's string key type).

eXist-db/exist#6491 makes map keys compare by `op:same-key` per XQuery 3.1 §17.1 — no cross-family coercion, so an `xs:integer` key no longer matches an `xs:string` key. The lookup then misses, the response definition comes back empty, the content type falls back to `application/xml`, `output:method` is set to `xml`, and a JSON response is serialized as XML — surfacing as `SENR0001` ("Cannot serialize a map(*) with the XML or text output method") on the forward-dispatch path. Routes that serialize JSON via the response-code → content-type negotiation are affected; a direct query that sets `output:method "json"` in its own prolog is not, which is why this only shows up through the router.

## Fix

Look up by the string form of the code:

```xquery
let $response-definition := head(($config?responses?(string($code)), $config?responses?default))
```

The OpenAPI response keys *are* strings, so this is correct on its own merits, and it matches on **both** current and pre-#6491 eXist (string-to-string always matched) — no eXist version floor is introduced.

## Scope

This is the only cross-family map lookup in `content/`. Every other dynamic lookup is string→string (media types, parameter names, method names) or `xs:QName`→`xs:QName` (the internal `router:RESPONSE_*` keys), none of which are affected by the `op:same-key` change.

## Test

Adds `test/responsetype.test.js`: a route that relies on response-code → content-type negotiation (`api:arrays-get` returns a bare `map` with no explicit response type) must serialize as `application/json`, not fall back to `application/xml`. The spec asserts the negotiated `Content-Type` and that the body is a parsed JSON object. It guards exactly this regression — it fails on eXist ≥ #6491 without the `string($code)` lookup, and passes with it.

## Verification

- The new spec passes (3/3) when run against an eXist build carrying #6491 with this fix installed; `GET /api/arrays` returns `200` with `Content-Type: application/json`.
- End-to-end on the same build with existdb-openapi + eXide: with stock roaster `1.12.1`, `GET /api/db` (and `/api/search`, `/api/db/resource`, eXide's `/api/storage`) returned `400 SENR0001`; with this fix, all return `200` with JSON.
- The mechanism was confirmed directly — on a #6491 build, `map{"200":"x"}(200)` returns the empty sequence while `map{"200":"x"}("200")` returns `"x"`.

## Context

This surfaced while testing eXist's map-key conformance fix (eXist-db/exist#6491) against a Roaster-based API stack. #6491 is correct; it exposed this latent reliance on the old coercion. Filing here so Roaster works on eXist both before and after that change lands.
