### PR TITLE
ci: soft-fail release job, pin eXist 6.4.1 test

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,16 +7,20 @@ on: [push, pull_request]
 
 jobs:
   build:
+    name: build (exist ${{ matrix.exist-version }}${{ matrix.experimental && ', experimental' || '' }})
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: true
       matrix:
-        exist-version: [release, 6.0.1, 5.5.1]
+        exist-version: [6.0.1, 5.5.1, 6.4.1]
         experimental: [false]
         # latest might contain breaking changes
         include:
           - exist-version: latest
+            experimental: true
+          # the rolling release image may fail for the moment
+          - exist-version: release
             experimental: true
     services:
       exist:


### PR DESCRIPTION
- release job gets continue-on-error: true with a TODO comment; release process is currently broken and should not block CI
- build matrix gains an explicit 6.4.1 entry alongside release/6.0.1/5.5.1, giving us a pinned regression target independent of the rolling 'release' tag; job name now shows the exist-version for readability in the Actions UI