### PR TITLE
feat(body)!: deliver array-typed and repeating form fields as arrays

### DIFF
--- a/content/body.xqm
+++ b/content/body.xqm
@@ -163,7 +163,13 @@ function body:get-form-data-value ($name as xs:string, $format as xs:string?) as
 
 declare %private
 function body:additional-property ($name as xs:string) as map(*) {
-    map { $name : request:get-parameter($name, ()) }
+    (: a repeating field is wrapped in an array - a sequence of more than one
+     : item cannot be serialized with the JSON output method (err:SERE0023)
+     : and multi-value parameters are arrays in $request?parameters as well :)
+    let $values := request:get-parameter($name, ())
+    return map {
+        $name : if (count($values) > 1) then array { $values } else $values
+    }
 };
 
 declare %private
@@ -189,6 +195,10 @@ function body:validate-value ($schema as map(*)) as function(*) {
                 then error($errors:BAD_REQUEST, 'Property "' || $name || '" is required!')
                 else if (count($value) > 1 and not($is-array))
                 then error($errors:BAD_REQUEST, 'Property "' || $name || '" only allows one item. Got ' || count($value), $value)
+                (: properties declared as type "array" are wrapped like
+                 : parameters:cast-array does for multi-value parameters :)
+                else if ($is-array and exists($value))
+                then map:entry($name, array { $value })
                 else map:entry($name, $value)
     }
 };

--- a/doc/file-upload.md
+++ b/doc/file-upload.md
@@ -133,7 +133,7 @@ In order to allow batch uploads only very few modifications to the above example
     }
     ```
 2. `<input type="file" multiple="true" />`
-3. iterate over all files in the body `for $file in $request?body?file`
+3. iterate over all files in the body `for $file in $request?body?file?*` (properties declared as type "array" are array values)
 4. return array of uploaded resources in response
 
 ```html
@@ -178,7 +178,7 @@ In order to allow batch uploads only very few modifications to the above example
 declare function upload:batch ($request as map(*)) {
     let $stored :=
         array{
-            for $file in $request?body?file
+            for $file in $request?body?file?*
             return xmldb:store(
                 "/db/apps/roasted/uploads", $file?name, $file?data)
         }

--- a/test/app/modules/upload.xqm
+++ b/test/app/modules/upload.xqm
@@ -26,7 +26,7 @@ declare function upload:single ($request as map(*)) {
 declare function upload:batch ($request as map(*)) {
     try {
         let $download-links as xs:string+ :=
-            for $file in $request?body?file
+            for $file in $request?body?file?*
             let $stored := xmldb:store($upload:collection, $file?name, $file?data)
             return $upload:download-path || $file?name
 

--- a/test/mediatype.test.js
+++ b/test/mediatype.test.js
@@ -540,6 +540,42 @@ test.
     })
 
 
+    describe("with one file posted to the batch route", function () {
+        let uploadResponse
+        const data = new FormData()
+
+        const fileName = 'only-file.txt'
+        const fileContent = 'the only text'
+        data.append('file', fileContent, {
+            knownLength: fileContent.length,
+            filename: fileName,
+            contentType: 'text/plain'
+        })
+        const headers = data.getHeaders();
+
+        before(function () {
+            return util.axios.post(
+                'upload/batch',
+                data,
+                { headers }
+            )
+            .then(r => uploadResponse = r)
+            .catch(e => uploadResponse = e.response )
+        })
+        // a property declared as type "array" is an array even for a single value
+        it("was uploaded", function () {
+            expect(uploadResponse.status).to.equal(201)
+            expect(uploadResponse.data.uploaded).to.deep.equal([
+                downloadApiEndpoint + fileName
+            ])
+        })
+        it('can be retrieved', async function () {
+            const res = await util.axios.get(uploadResponse.data.uploaded[0], { responseType: 'arraybuffer' })
+            expect(res.status).to.equal(200)
+            expect(res.data.toString()).to.eql(fileContent, 'File content differs')
+        })
+    })
+
     describe("with two files", function () {
         let uploadResponse
         const data = new FormData()


### PR DESCRIPTION
Implements **Option 1** from #144: form-body values declared as `type: "array"` — and repeating schemaless fields — are delivered to handlers as `array(*)` instead of XQuery sequences.

## Why

eXist 7 made JSON serialization spec-compliant: the JSON output method now raises `err:SERE0023` for a map entry whose value is a sequence of more than one item, where eXist ≤ 6.x silently coerced it to a JSON array. Any handler serializing `$request?body` from a form post with a repeating field therefore 500s on eXist 7 — this is what fails the two experimental CI jobs (`existdb/existdb:latest` / `:release`) on `main`.

Beyond the eXist 7 breakage, this fixes an internal inconsistency (see [#144 comment](https://github.com/eeditiones/roaster/issues/144#issuecomment-5507561982)): `parameters:cast-array` already returns `array(*)` for array-typed parameters, and JSON bodies naturally produce arrays — form bodies were the only place where the same declared schema type produced a sequence.

## Changes

- `content/body.xqm`
  - `body:validate-value`: a property declared `type: "array"` is wrapped in `array { }` when present (absent optional properties keep producing the empty sequence, matching `parameters:cast-array`).
  - `body:additional-property` (schemaless / undeclared fields): a repeating field is wrapped in an array; single values stay scalar (without a schema there is nothing that says "array").
- `test/app/modules/upload.xqm`: `upload:batch` unpacks the array (`$request?body?file?*`).
- `doc/file-upload.md`: batch examples updated accordingly.
- `test/mediatype.test.js`: new test posting a **single** file to the batch route — a declared-array property must be an array even with one value. The previously failing urlencoded tests pass unchanged, since `serialize(map { …, "array": [1,2,3] }, map { "method": "json" })` is valid on every eXist version.

## Breaking change

Handlers reading **multi-value form-data/urlencoded body fields** must unpack an array now (`$request?body?file?*` instead of `$request?body?file`). Parameter handling and JSON bodies are unaffected — they were already arrays. The commit carries a `BREAKING CHANGE:` footer so semantic-release cuts a major version.

## Verification

Full suite run against both engines via Docker containers:

| Engine | Result |
|---|---|
| eXist 6.4.1 | 197 passing, 0 failing |
| eXist 7.0.0-SNAPSHOT (`existdb/existdb:latest`) | 197 passing, 0 failing (was 2 failing on `main`) |

The experimental CI jobs should go green with this change.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L13cpTBpxHDuvVSd78BDQw
