### PR TITLE
Be strict(er) in matching of last path component

### DIFF
--- a/content/router.xql
+++ b/content/router.xql
@@ -203,21 +203,11 @@ declare %private function router:create-regex($path as xs:string) as xs:string {
         return replace($component, $router:path-parameter-matcher, $replacement)
     
     return
-        (: allow (but don't require) a single trailing slash after the last component,
-         : e.g. both "/api/reconcile" and "/api/reconcile/" match "^/api/reconcile/?$" -
-         : still anchored, so this doesn't reopen the prefix over-matching that the "$"
-         : anchor itself was added to fix (eeditiones/roaster#122): "/api/reconcile/v0.2"
-         : still requires its own distinct route.
-         :
-         : Without the "$"/"/?$" anchor at all (i.e. on an unpatched roaster before this
-         : fix), any request path that merely *starts with* a declared route wrongly
-         : matches it instead of 404ing - e.g. against the reconcile profile in
-         : mpilhlt/tei-publisher-reconcile, "GET /api/reconcile/v0.2" (a nonexistent path,
-         : not the "?version=0.2" query param the manifest actually uses) matched the bare
-         : "/api/reconcile" route and wrongly returned its manifest instead of a 404. See
-         : that project's docker/README.md ("GET /api/reconcile/v0.2 (or any path merely
-         : *starting with* a declared route) wrongly matches that route") for the concrete
-         : repro and regression coverage. :)
+        (: disallow any continuation of the last component except for a trailing slash to match.
+         : e.g. both "$base/resource/Patient" and "$base/resource/Patient/" match a
+         : "/resource/Patient" pattern, but "$base/resource/Patient123" or
+         : "/resource/Patient/123" do not. :)
+
         "^/" || string-join($replaced, "/") || "/?$"
 };
 

--- a/content/router.xql
+++ b/content/router.xql
@@ -203,7 +203,12 @@ declare %private function router:create-regex($path as xs:string) as xs:string {
         return replace($component, $router:path-parameter-matcher, $replacement)
     
     return
-        "^/" || string-join($replaced, "/") || "$"
+        (: allow (but don't require) a single trailing slash after the last component,
+         : e.g. both "/api/reconcile" and "/api/reconcile/" match "^/api/reconcile/?$" -
+         : still anchored, so this doesn't reopen the prefix over-matching that the "$"
+         : anchor itself was added to fix (eeditiones/roaster#122): "/api/reconcile/v0.2"
+         : still requires its own distinct route. :)
+        "^/" || string-join($replaced, "/") || "/?$"
 };
 
 declare %private function router:add-specificity ($route as map(*)) as map(*) {

--- a/content/router.xql
+++ b/content/router.xql
@@ -203,7 +203,7 @@ declare %private function router:create-regex($path as xs:string) as xs:string {
         return replace($component, $router:path-parameter-matcher, $replacement)
     
     return
-        "^/" || string-join($replaced, "/")
+        "^/" || string-join($replaced, "/") || "$"
 };
 
 declare %private function router:add-specificity ($route as map(*)) as map(*) {

--- a/content/router.xql
+++ b/content/router.xql
@@ -207,7 +207,17 @@ declare %private function router:create-regex($path as xs:string) as xs:string {
          : e.g. both "/api/reconcile" and "/api/reconcile/" match "^/api/reconcile/?$" -
          : still anchored, so this doesn't reopen the prefix over-matching that the "$"
          : anchor itself was added to fix (eeditiones/roaster#122): "/api/reconcile/v0.2"
-         : still requires its own distinct route. :)
+         : still requires its own distinct route.
+         :
+         : Without the "$"/"/?$" anchor at all (i.e. on an unpatched roaster before this
+         : fix), any request path that merely *starts with* a declared route wrongly
+         : matches it instead of 404ing - e.g. against the reconcile profile in
+         : mpilhlt/tei-publisher-reconcile, "GET /api/reconcile/v0.2" (a nonexistent path,
+         : not the "?version=0.2" query param the manifest actually uses) matched the bare
+         : "/api/reconcile" route and wrongly returned its manifest instead of a 404. See
+         : that project's docker/README.md ("GET /api/reconcile/v0.2 (or any path merely
+         : *starting with* a declared route) wrongly matches that route") for the concrete
+         : repro and regression coverage. :)
         "^/" || string-join($replaced, "/") || "/?$"
 };
 


### PR DESCRIPTION
My testsuite for https://github.com/mpilhlt/tei-publisher-reconcile has turned up some errors, one of them concerning roaster. It seems the matching of path parameters would allow any last component that had the required string *as a prefix* to match. See also #122. This PR should fix this (while allowing a trailing slash).

For the testsuite and description of the context in which I encountered this, see https://github.com/mpilhlt/tei-publisher-reconcile/blob/main/docker/README.md#verified-end-to-end
